### PR TITLE
Fix E402 imports and logging

### DIFF
--- a/python/packages/autogen-cpas/src/cpas_autogen/__init__.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/__init__.py
@@ -1,20 +1,20 @@
-from .seed_token import SeedToken
-from .epistemic_fingerprint import generate_fingerprint
-from .prompt_wrapper import wrap_with_seed_token
 from .continuity_check import continuity_check
-from .realignment_trigger import should_realign
-from .metrics_monitor import periodic_metrics_check
 from .drift_monitor import latest_metrics
+from .epistemic_fingerprint import generate_fingerprint
+from .metrics_monitor import periodic_metrics_check
 from .mixins import EpistemicAgentMixin
+from .prompt_wrapper import wrap_with_seed_token
+from .realignment_trigger import should_realign
+from .seed_token import SeedToken
 
 __all__ = [
-    'SeedToken',
-    'generate_fingerprint',
-    'wrap_with_seed_token',
-    'continuity_check',
-    'should_realign',
-    'periodic_metrics_check',
-    'latest_metrics',
-    'EpistemicAgentMixin',
+    "SeedToken",
+    "generate_fingerprint",
+    "wrap_with_seed_token",
+    "continuity_check",
+    "should_realign",
+    "periodic_metrics_check",
+    "latest_metrics",
+    "EpistemicAgentMixin",
 ]
-__version__ = '0.1.0'
+__version__ = "0.1.0"

--- a/python/packages/autogen-cpas/src/cpas_autogen/continuity_check.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/continuity_check.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Token continuity verification utilities."""
+
+from __future__ import annotations
 
 import logging
 

--- a/python/packages/autogen-cpas/src/cpas_autogen/drift_monitor.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/drift_monitor.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utility functions for retrieving latest drift metrics."""
+
+from __future__ import annotations
 
 import json
 from pathlib import Path

--- a/python/packages/autogen-cpas/src/cpas_autogen/epistemic_fingerprint.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/epistemic_fingerprint.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
-
 """Epistemic fingerprint generation utilities."""
 
-from datetime import datetime
+from __future__ import annotations
+
 import hashlib
+from datetime import datetime
 
 
 def generate_fingerprint(prompt: str, seed_token: dict) -> dict:

--- a/python/packages/autogen-cpas/src/cpas_autogen/generate_agents.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/generate_agents.py
@@ -9,10 +9,11 @@ except Exception:  # pragma: no cover - optional dependency
     def config_list_from_models(*args, **kwargs):  # type: ignore[return-type]
         return []
 
-from cpas_autogen.seed_token import SeedToken
-from cpas_autogen.prompt_wrapper import wrap_with_seed_token
-from cpas_autogen.continuity_check import continuity_check
 import logging
+
+from cpas_autogen.continuity_check import continuity_check
+from cpas_autogen.prompt_wrapper import wrap_with_seed_token
+from cpas_autogen.seed_token import SeedToken
 
 ROOT = Path(__file__).resolve().parents[1]
 JSON_DIR = ROOT / "agents" / "json"
@@ -25,17 +26,17 @@ def create_system_message(idp: dict) -> str:
         f"CPAS IDP v{idp.get('idp_version')} instance declaration",
         f"Deployment Context: {idp.get('deployment_context')}",
     ]
-    capabilities = idp.get('declared_capabilities', [])
+    capabilities = idp.get("declared_capabilities", [])
     if capabilities:
         lines.append("Capabilities:\n" + "\n".join(f"- {c}" for c in capabilities))
-    constraints = idp.get('declared_constraints', [])
+    constraints = idp.get("declared_constraints", [])
     if constraints:
         lines.append("Constraints:\n" + "\n".join(f"- {c}" for c in constraints))
-    if idp.get('interaction_style'):
+    if idp.get("interaction_style"):
         lines.append(f"Interaction Style: {idp['interaction_style']}")
-    if idp.get('epistemic_stance'):
+    if idp.get("epistemic_stance"):
         lines.append(f"Epistemic Stance: {idp['epistemic_stance']}")
-    if idp.get('ethical_framework'):
+    if idp.get("ethical_framework"):
         lines.append(f"Ethical Framework: {idp['ethical_framework']}")
     return "\n".join(lines)
 
@@ -58,7 +59,7 @@ def generate_agent_module(json_path: Path) -> str:
         "\nconfig_list = config_list_from_models([IDP_METADATA['model_family']])",
         "",
         "def create_agent():",
-        "    \"\"\"Return a ConversableAgent configured from IDP metadata.\"\"\"",
+        '    """Return a ConversableAgent configured from IDP metadata."""',
         "    system_message = '''" + create_system_message(idp) + "'''",
         "    agent = ConversableAgent(",
         "        name=IDP_METADATA['instance_name'],",
@@ -98,7 +99,7 @@ def main():
         py_name = json_file.with_suffix(".py").name
         out_path = PY_DIR / py_name
         out_path.write_text(module_text)
-        print(f"Generated {out_path.relative_to(ROOT)}")
+        logging.info("Generated %s", out_path.relative_to(ROOT))
 
 
 if __name__ == "__main__":

--- a/python/packages/autogen-cpas/src/cpas_autogen/metrics_monitor.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/metrics_monitor.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for comparing live metrics to baseline values."""
+
+from __future__ import annotations
 
 import json
 import logging
@@ -8,8 +8,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict
 
+from .config import BASELINE_FILE, EXAMPLES_DIR
 from .instance_diff_engine import similarity_score
-from .config import EXAMPLES_DIR, BASELINE_FILE
 
 # Default interval for periodic checks (in minutes)
 DEFAULT_INTERVAL = timedelta(minutes=30)

--- a/python/packages/autogen-cpas/src/cpas_autogen/mixins.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/mixins.py
@@ -4,13 +4,13 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from .seed_token import SeedToken
-from .prompt_wrapper import wrap_with_seed_token
-from .epistemic_fingerprint import generate_fingerprint
 from .continuity_check import continuity_check
-from .metrics_monitor import periodic_metrics_check
 from .drift_monitor import latest_metrics
+from .epistemic_fingerprint import generate_fingerprint
+from .metrics_monitor import periodic_metrics_check
+from .prompt_wrapper import wrap_with_seed_token
 from .realignment_trigger import should_realign
+from .seed_token import SeedToken
 
 
 class EpistemicAgentMixin:

--- a/python/packages/autogen-cpas/src/cpas_autogen/realignment_trigger.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/realignment_trigger.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Realignment trigger utility."""
+
+from __future__ import annotations
 
 import logging
 from typing import Dict


### PR DESCRIPTION
## Summary
- reorder imports in all CPAS modules per E402
- replace print with logging in `generate_agents.py`
- ensure ruff check passes

## Testing
- `poetry run ruff check --no-fix src/cpas_autogen`

------
https://chatgpt.com/codex/tasks/task_e_6853fc89892c832d8c32e1fa327db1c4