### PR TITLE
Fix wheel package config

### DIFF
--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -9,4 +9,4 @@ readme = "README.md"
 dependencies = ["openai", "numpy", "scikit-learn"]  # as needed
 
 [tool.hatch.build.targets.wheel]
-packages = ["autogen_cpas"]
+packages = ["cpas_autogen"]


### PR DESCRIPTION
## Summary
- correct package target in autogen-cpas `pyproject.toml`
- verify build and installation

## Testing
- `pip install -e ./python/packages/autogen-cpas`
- `pytest python/packages/autogen-cpas/tests`

------
https://chatgpt.com/codex/tasks/task_e_685424baab04832da91d570435da8c11