### PR TITLE
Fix validate_idp test path

### DIFF
--- a/python/packages/autogen-cpas/tests/test_validate_idp.py
+++ b/python/packages/autogen-cpas/tests/test_validate_idp.py
@@ -3,13 +3,13 @@ import pytest
 pytest.importorskip("jsonschema")
 import runpy
 
-validate_module = runpy.run_path("instances/schema/validation-tools/validate_idp.py")
+validate_module = runpy.run_path("python/packages/autogen-cpas/tests/validate_idp.py")
 validate_instance = validate_module["validate_instance"]
 
 
 def test_validate_instance_pass(capsys):
-    instance = "agents/json/openai-gpt4/Clarence-9.json"
-    schema = "instances/schema/current/idp-v1.0-schema.json"
+    instance = "agents/json/openai/Clarence-9.json"
+    schema = "agents/idp-v1.0-schema.json"
     validate_instance(instance, schema)
     captured = capsys.readouterr().out
     assert "Validation passed" in captured


### PR DESCRIPTION
## Summary
- update runpy target in `test_validate_idp.py`
- use correct instance and schema paths

## Testing
- `pytest python/packages/autogen-cpas/tests/test_validate_idp.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_68542a2e7948832d94f67b68b6ecfed6