### PR TITLE
Fix baseline metrics path

### DIFF
--- a/python/packages/autogen-cpas/tools/baseline_metrics.py
+++ b/python/packages/autogen-cpas/tools/baseline_metrics.py
@@ -46,7 +46,7 @@ def divergence_space(texts: list[str], nlp) -> float:
 
 
 def main():
-    base = Path("metaphor-library/DKA-E")
+    base = Path(__file__).resolve().parents[1] / "metaphor-library" / "DKA-E"
     texts = load_metaphor_texts(base)
     nlp = spacy.load("en_core_web_sm")
 


### PR DESCRIPTION
## Summary
- fix baseline_metrics path resolution

## Testing
- `pytest -k baseline_metrics -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat', plus other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68543d6f56c8832d81a51e883b11577c