### PR TITLE
Fix wheel target path

### DIFF
--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -18,4 +18,4 @@ dependencies = [
 ]  # as needed
 
 [tool.hatch.build.targets.wheel]
-packages = ["cpas_autogen"]
+packages = ["src/cpas_autogen"]


### PR DESCRIPTION
## Summary
- point wheel packages to `src/cpas_autogen`

## Testing
- `pip install -e . --no-deps`
- `python -c 'import cpas_autogen, sys; print(cpas_autogen.__file__)'`

------
https://chatgpt.com/codex/tasks/task_e_685450ea868c832d8edbed4532e59558