### PR TITLE
Fix agent generation example

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -20,7 +20,7 @@ Execute the generator from the repository root:
 agents/generate_autogen_agents.py
 ```
 
-The script walks through `agents/json/` and writes a Python file with the same base name to `agents/python/`. For example, `agents/json/openai/Clarence-9.json` becomes `agents/python/Clarence-9.py`.
+The script walks through `agents/json/` and writes a Python file with the same base name to `agents/python/`. For example, `agents/json/openai/Clarence-9.json` becomes `agents/python/Clarence_9.py`.
 Each module exposes a `create_agent()` helper that constructs a `ConversableAgent` using the JSON metadata and a `send_message()` function for convenience.
 
 


### PR DESCRIPTION
## Summary
- fix `agents/README.md` mapping example for Clarence-9

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_68545268a28c832d81afc9fe5ce1dda9