### PR TITLE
Add simple autogen_cpas package and tests

### DIFF
--- a/python/packages/autogen-cpas/LICENSE-CODE
+++ b/python/packages/autogen-cpas/LICENSE-CODE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -3,19 +3,34 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "cpas_autogen"
+name = "autogen-cpas"
 version = "0.1.0"
+license = {file = "LICENSE-CODE"}
+description = "CPAS utilities for AutoGen"
 readme = "README.md"
+requires-python = ">=3.10"
 dependencies = [
-  "openai",
-  "numpy",
-  "scikit-learn",
-  "spacy",
-  "torch",
-  "sentence-transformers",
-  "pandas",
-  "matplotlib",
-]  # as needed
+    "autogen-core==0.6.1",
+    "pydantic>=2,<3",
+]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/cpas_autogen"]
+packages = ["src/autogen_cpas"]
+
+[tool.ruff]
+extend = "../../pyproject.toml"
+include = ["src/**", "tests/*.py"]
+
+[tool.pyright]
+extends = "../../pyproject.toml"
+include = ["src", "tests"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = ["tests"]
+
+[tool.poe]
+include = "../../shared_tasks.toml"
+
+[tool.poe.tasks]
+test = "pytest -n auto --cov=src --cov-report=term-missing --cov-report=xml"

--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,0 +1,5 @@
+from .models import ChatMessage
+from .protocol import Role
+from .agent import EchoAgent
+
+__all__ = ["ChatMessage", "Role", "EchoAgent"]

--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -1,0 +1,15 @@
+from autogen_core import MessageContext, RoutedAgent, message_handler
+
+from .models import ChatMessage
+from .protocol import Role
+
+
+class EchoAgent(RoutedAgent):
+    """Minimal agent that echoes user content."""
+
+    def __init__(self) -> None:
+        super().__init__("Echo agent")
+
+    @message_handler
+    async def handle_message(self, message: ChatMessage, ctx: MessageContext) -> ChatMessage:
+        return ChatMessage(role=Role.ASSISTANT, content=message.content)

--- a/python/packages/autogen-cpas/src/autogen_cpas/models.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/models.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+from .protocol import Role
+
+
+class ChatMessage(BaseModel):
+    """Simple chat message used for tests."""
+
+    role: Role
+    content: str

--- a/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Role(str, Enum):
+    """Sender role for a chat message."""
+
+    USER = "user"
+    ASSISTANT = "assistant"

--- a/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
+++ b/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
@@ -1,0 +1,20 @@
+import pytest
+from autogen_core import AgentId, SingleThreadedAgentRuntime
+
+from autogen_cpas.agent import EchoAgent
+from autogen_cpas.models import ChatMessage
+from autogen_cpas.protocol import Role
+
+
+@pytest.mark.asyncio
+async def test_agent_roundtrip() -> None:
+    runtime = SingleThreadedAgentRuntime()
+    await EchoAgent.register(runtime, "echo", EchoAgent)
+    runtime.start()
+    response = await runtime.send_message(
+        ChatMessage(role=Role.USER, content="ping"), recipient=AgentId("echo", "default")
+    )
+    await runtime.stop()
+    assert isinstance(response, ChatMessage)
+    assert response.role is Role.ASSISTANT
+    assert response.content == "ping"

--- a/python/packages/autogen-cpas/tests/test_models.py
+++ b/python/packages/autogen-cpas/tests/test_models.py
@@ -1,0 +1,8 @@
+from autogen_cpas.models import ChatMessage
+from autogen_cpas.protocol import Role
+
+
+def test_roundtrip() -> None:
+    msg = ChatMessage(role=Role.USER, content="hello")
+    data = msg.model_dump()
+    assert ChatMessage.model_validate(data) == msg


### PR DESCRIPTION
## Summary
- introduce new `autogen_cpas` package with basic echo agent
- implement `ChatMessage` model and protocol `Role`
- configure package metadata and dependencies
- add tests for model serialization and agent runtime integration

## Testing
- `pip install --no-deps -e ../autogen-core`
- `pip install --no-deps -e .`
- `pip install protobuf~=5.29.3`
- `pip install 'pydantic>=2,<3'`
- `pip install pillow>=11.0.0`
- `pip install opentelemetry-api>=1.34.1 opentelemetry-semantic-conventions==0.55b1`
- `pip install jsonref~=1.1.0`
- `pip install pytest-asyncio`
- `pytest -q tests/test_models.py tests/test_agent_roundtrip.py`

------
https://chatgpt.com/codex/tasks/task_e_6857946aad04832d8d9cb75b63726dca