### PR TITLE
Add CPAS metadata and TBeep message models

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,5 +1,12 @@
-from .models import ChatMessage
-from .protocol import Role
 from .agent import EchoAgent
+from .models import ChatMessage, CPASMetadata, TBeepMessage
+from .protocol import RIFG, Role
 
-__all__ = ["ChatMessage", "Role", "EchoAgent"]
+__all__ = [
+    "ChatMessage",
+    "CPASMetadata",
+    "TBeepMessage",
+    "Role",
+    "RIFG",
+    "EchoAgent",
+]

--- a/python/packages/autogen-cpas/src/autogen_cpas/models.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/models.py
@@ -1,6 +1,11 @@
-from pydantic import BaseModel
+from __future__ import annotations
 
-from .protocol import Role
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, field_validator
+
+from .protocol import RIFG, Role
 
 
 class ChatMessage(BaseModel):
@@ -8,3 +13,42 @@ class ChatMessage(BaseModel):
 
     role: Role
     content: str
+
+
+class CPASMetadata(BaseModel):
+    """Metadata embedded in T-BEEP messages."""
+
+    confidence: float
+    rifg: RIFG
+    provenance: List[str]
+    notes: Optional[str] = None
+
+    @field_validator("confidence")
+    @classmethod
+    def _check_precision(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        if round(v, 3) != v:
+            raise ValueError("confidence must have at most 3 decimal places")
+        return v
+
+
+class TBeepMessage(BaseModel):
+    """Structured T-BEEP message with CPAS metadata."""
+
+    id: str
+    timestamp: datetime
+    role: Role
+    sender: str
+    recipient: str
+    content: str
+    metadata: CPASMetadata
+
+    def to_dict(self) -> dict:
+        """Return the serializable representation."""
+        return self.model_dump()
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TBeepMessage":
+        """Create a :class:`TBeepMessage` from a dictionary."""
+        return cls.model_validate(data)

--- a/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
@@ -6,3 +6,15 @@ class Role(str, Enum):
 
     USER = "user"
     ASSISTANT = "assistant"
+    AGENT = "agent"
+    SYSTEM = "system"
+
+
+class RIFG(float, Enum):
+    """Reflective Inference Fidelity Grade."""
+
+    VERY_LOW = 0.0
+    LOW = 0.25
+    MEDIUM = 0.5
+    HIGH = 0.75
+    VERY_HIGH = 1.0

--- a/python/packages/autogen-cpas/tests/test_tbeep_message_models.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_message_models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+import pytest
+
+from autogen_cpas.models import CPASMetadata, TBeepMessage
+from autogen_cpas.protocol import RIFG, Role
+
+
+def test_metadata_precision():
+    CPASMetadata(confidence=0.5, rifg=RIFG.MEDIUM, provenance=["test"])
+    with pytest.raises(ValueError):
+        CPASMetadata(confidence=0.1234, rifg=RIFG.MEDIUM, provenance=["test"])
+
+
+def test_message_roundtrip():
+    meta = CPASMetadata(confidence=0.9, rifg=RIFG.HIGH, provenance=["unit"])
+    msg = TBeepMessage(
+        id="1",
+        timestamp=datetime(2025, 1, 1, 0, 0, 0),
+        role=Role.USER,
+        sender="alice",
+        recipient="bob",
+        content="hello",
+        metadata=meta,
+    )
+    data = msg.to_dict()
+    assert TBeepMessage.from_dict(data) == msg


### PR DESCRIPTION
## Summary
- extend `Role` enum with AGENT and SYSTEM
- add `RIFG` float enum
- implement `CPASMetadata` pydantic model with validation
- implement `TBeepMessage` model with serialization helpers
- export new models
- test roundtrip and precision validation

## Testing
- `ruff check python/packages/autogen-cpas/src/autogen_cpas python/packages/autogen-cpas/tests/test_tbeep_message_models.py`
- `PYTHONPATH=src pytest -q tests/test_tbeep_message_models.py` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_6857ef4836ac832da0100cacf1eba506