### PR TITLE
Add CpasEnabledAgent

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,6 +1,6 @@
-from .agent import EchoAgent
+from .agent import CpasEnabledAgent, EchoAgent
 from .models import ChatMessage, CPASMetadata, TBeepMessage
-from .protocol import RIFG, Role
+from .protocol import RIFG, Role, decode, encode
 
 __all__ = [
     "ChatMessage",
@@ -9,4 +9,7 @@ __all__ = [
     "Role",
     "RIFG",
     "EchoAgent",
+    "CpasEnabledAgent",
+    "encode",
+    "decode",
 ]

--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -1,7 +1,13 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from autogen.core import ConversableAgent
 from autogen_core import MessageContext, RoutedAgent, message_handler
 
-from .models import ChatMessage
-from .protocol import Role
+from .models import ChatMessage, CPASMetadata, TBeepMessage
+from .protocol import Role, decode, encode
 
 
 class EchoAgent(RoutedAgent):
@@ -13,3 +19,34 @@ class EchoAgent(RoutedAgent):
     @message_handler
     async def handle_message(self, message: ChatMessage, ctx: MessageContext) -> ChatMessage:
         return ChatMessage(role=Role.ASSISTANT, content=message.content)
+
+
+class CpasEnabledAgent(ConversableAgent):
+    """Conversable agent that echoes messages with updated CPAS metadata."""
+
+    def receive(self, message, sender=None, **kwargs):  # type: ignore[override]
+        """Validate ``message`` using :func:`decode` before delegating."""
+        decode(message)
+        return super().receive(message, sender=sender, **kwargs)
+
+    def generate_reply(self, messages, sender=None, **kwargs):  # type: ignore[override]
+        """Return an echo response with incremented confidence and provenance."""
+        raw = messages[-1]
+        incoming = decode(raw)
+        meta = incoming.metadata
+        new_meta = CPASMetadata(
+            confidence=min(meta.confidence + 0.1, 1.0),
+            rifg=meta.rifg,
+            provenance=[*meta.provenance, self.name],
+            notes=meta.notes,
+        )
+        reply = TBeepMessage(
+            id=str(uuid.uuid4()),
+            timestamp=datetime.utcnow(),
+            role=Role.ASSISTANT,
+            sender=self.name,
+            recipient=incoming.sender,
+            content=incoming.content,
+            metadata=new_meta,
+        )
+        return encode(reply)

--- a/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from enum import Enum
+
+from .models import TBeepMessage
 
 
 class Role(str, Enum):
@@ -18,3 +22,18 @@ class RIFG(float, Enum):
     MEDIUM = 0.5
     HIGH = 0.75
     VERY_HIGH = 1.0
+
+
+def encode(message: TBeepMessage) -> dict:
+    """Return a dictionary representation of ``message``."""
+    return message.to_dict()
+
+
+def decode(data: dict) -> TBeepMessage:
+    """Validate ``data`` and return a :class:`TBeepMessage`."""
+    if not isinstance(data, dict):
+        raise TypeError("message must be a dictionary")
+    return TBeepMessage.from_dict(data)
+
+
+__all__ = ["Role", "RIFG", "encode", "decode"]


### PR DESCRIPTION
## Summary
- add encode/decode helpers in `protocol`
- implement `CpasEnabledAgent` based on AutoGen's ConversableAgent
- expose new utilities in package `__init__`

## Testing
- `ruff check python/packages/autogen-cpas/src/autogen_cpas/agent.py python/packages/autogen-cpas/src/autogen_cpas/protocol.py python/packages/autogen-cpas/src/autogen_cpas/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6857f372ca34832d84c4985fe520ad62