### PR TITLE
Add reflection to AssistantAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+### Recording Thoughts
+
+Store a quick reflection after each run using a memory implementation.
+
+```python
+import asyncio
+from autogen_agentchat.agents import AssistantAgent
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_core.memory import ListMemory
+
+async def main() -> None:
+    memory = ListMemory()
+    model_client = OpenAIChatCompletionClient(model="gpt-4o")
+    agent = AssistantAgent("assistant", model_client=model_client, memory=[memory])
+    await agent.run(task="Any tips for today?", reflect=True, scaffold_metadata={"stage": "demo"})
+    print(memory.content[-1].content)
+    await model_client.close()
+
+asyncio.run(main())
+```
+
 ### Web Browsing Agent Team
 
 Create a group chat team with a web surfer agent and a user proxy agent

--- a/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
+++ b/python/packages/autogen-agentchat/src/autogen_agentchat/agents/_assistant_agent.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from autogen_core import CancellationToken, Component, ComponentModel, FunctionCall
-from autogen_core.memory import Memory
+from autogen_core.memory import Memory, MemoryContent, MemoryMimeType
 from autogen_core.model_context import (
     ChatCompletionContext,
     UnboundedChatCompletionContext,
@@ -38,7 +38,7 @@ from typing_extensions import Self
 
 from .. import EVENT_LOGGER_NAME
 from ..base import Handoff as HandoffBase
-from ..base import Response
+from ..base import Response, TaskResult
 from ..messages import (
     BaseAgentEvent,
     BaseChatMessage,
@@ -378,7 +378,9 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
                         reflect_on_tool_use=True,
                     )
                     await Console(
-                        assistant.run_stream(task="Go to https://github.com/microsoft/autogen and tell me what you see.")
+                        assistant.run_stream(
+                            task="Go to https://github.com/microsoft/autogen and tell me what you see."
+                        )
                     )
 
 
@@ -1379,6 +1381,52 @@ class AssistantAgent(BaseChatAgent, Component[AssistantAgentConfig]):
         assistant_agent_state = AssistantAgentState.model_validate(state)
         # Load the model context state.
         await self._model_context.load_state(assistant_agent_state.llm_context)
+
+    async def reflect(
+        self,
+        messages: Sequence[BaseAgentEvent | BaseChatMessage],
+        *,
+        scaffold_metadata: Dict[str, str] | None = None,
+    ) -> None:
+        """Record a summary or thought event into memory."""
+
+        if not self._memory:
+            return
+
+        thoughts = [m.content for m in messages if isinstance(m, ThoughtEvent)]
+        if thoughts:
+            summary = "\n".join(thoughts)
+        elif messages:
+            last = messages[-1]
+            if hasattr(last, "to_text"):
+                summary = last.to_text()
+            else:
+                summary = str(getattr(last, "content", ""))
+        else:
+            summary = ""
+
+        mem_content = MemoryContent(
+            content=summary,
+            mime_type=MemoryMimeType.TEXT,
+            metadata=scaffold_metadata,
+        )
+        for mem in self._memory:
+            await mem.add(mem_content)
+
+    async def run(
+        self,
+        *,
+        task: str | BaseChatMessage | Sequence[BaseChatMessage] | None = None,
+        cancellation_token: CancellationToken | None = None,
+        reflect: bool = False,
+        scaffold_metadata: Dict[str, str] | None = None,
+    ) -> TaskResult:
+        """Run the agent and optionally reflect after completion."""
+
+        result = await super().run(task=task, cancellation_token=cancellation_token)
+        if reflect and not self._reflect_on_tool_use:
+            await self.reflect(result.messages, scaffold_metadata=scaffold_metadata)
+        return result
 
     @staticmethod
     def _get_compatible_context(model_client: ChatCompletionClient, messages: List[LLMMessage]) -> Sequence[LLMMessage]:

--- a/python/packages/autogen-agentchat/tests/test_assistant_agent.py
+++ b/python/packages/autogen-agentchat/tests/test_assistant_agent.py
@@ -1632,3 +1632,28 @@ async def test_tools_deserialize_aware() -> None:
     assert result.messages[-1].content == "Hello, World!"  # type: ignore
     assert result.messages[-1].type == "ToolCallSummaryMessage"  # type: ignore
     assert isinstance(result.messages[-1], ToolCallSummaryMessage)  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_adds_memory() -> None:
+    model_client = ReplayChatCompletionClient(["Hi"])
+    memory = ListMemory()
+    agent = AssistantAgent("assistant", model_client=model_client, memory=[memory])
+    await agent.run(task="hello", reflect=True, scaffold_metadata={"tag": "test"})
+    assert len(memory.content) == 1
+    assert memory.content[0].metadata == {"tag": "test"}
+    assert "Hi" in str(memory.content[0].content)
+
+
+@pytest.mark.asyncio
+async def test_run_reflection_skipped_when_tool_reflection_enabled() -> None:
+    model_client = ReplayChatCompletionClient(["Hi"])
+    memory = ListMemory()
+    agent = AssistantAgent(
+        "assistant",
+        model_client=model_client,
+        memory=[memory],
+        reflect_on_tool_use=True,
+    )
+    await agent.run(task="hello", reflect=True)
+    assert len(memory.content) == 0


### PR DESCRIPTION
## Summary
- record reflection via `AssistantAgent.reflect()`
- tag reflections with optional metadata
- integrate reflection into `AssistantAgent.run`
- document quickstart reflections
- test new reflection logic

## Testing
- `python -m pytest python/packages/autogen-agentchat/tests/test_assistant_agent.py -k "run_reflection" -q`

------
https://chatgpt.com/codex/tasks/task_e_685833bb22d4832d94108af1b1fcaded