### PR TITLE
Expose CLI entrypoints for autogen-cpas

### DIFF
--- a/python/packages/autogen-cpas/README.md
+++ b/python/packages/autogen-cpas/README.md
@@ -41,9 +41,9 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 git clone <repo-url> && cd Reflective-AI-and-CPAS-Core
 pip install -r requirements.txt
 pip install -e ".[web]"
-python tools/generate_autogen_agents.py
+autogen-cpas-gen-agents
 streamlit run ui/dashboard.py &
-flask run --app api/tbeep_api.py
+autogen-cpas-api
 ```
 
 ## Installation
@@ -79,7 +79,7 @@ messages in memory only. Persistent storage and authentication are pending. This
 feature also requires the `web` extras. Start the API with:
 
 ```bash
-python api/tbeep_api.py
+autogen-cpas-api
 ```
 
 Messages can then be POSTed to `/api/v1/messages` and fetched by thread ID via `GET /api/v1/messages?thread_id=`.

--- a/python/packages/autogen-cpas/api/tbeep_api.py
+++ b/python/packages/autogen-cpas/api/tbeep_api.py
@@ -38,5 +38,10 @@ def get_messages():
     return jsonify(MESSAGE_STORE.get(thread_id, []))
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Run the development server."""
     app.run(debug=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
     "pydantic>=2,<3",
 ]
 
+[project.scripts]
+autogen-cpas-api = "autogen_cpas.api.tbeep_api:main"
+autogen-cpas-gen-agents = "cpas_autogen.generate_agents:main"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/autogen_cpas"]
 


### PR DESCRIPTION
## Summary
- add console scripts to `pyproject.toml`
- expose `main()` in `tbeep_api.py`
- document usage of new `autogen-cpas-*` commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68583818e1a8832da10462d27ba784e4