### PR TITLE
Add JSON schema files

### DIFF
--- a/python/packages/autogen-cpas/README.md
+++ b/python/packages/autogen-cpas/README.md
@@ -33,6 +33,8 @@ A modular standard for layered AI interaction, cross-instance collaboration, and
 ### Additional Resources
 
 - [**CPAS-Core v1.1 Specification**](docs/specs/current/CPAS-Core-v1.1.md)
+- [**CPAS Metadata Schema**](../../schema/cpas_metadata.schema.json)
+- [**T-BEEP Message Schema**](../../schema/tbeep_message.schema.json)
 - [**Changelog**](docs/specs/CHANGELOG.md)
 - [**Metaphor Library (including DKA-E metaphors)**](./metaphor-library/)
 - [**Compliance Tests**](./compliance-tests/)

--- a/python/packages/autogen-cpas/docs/index.md
+++ b/python/packages/autogen-cpas/docs/index.md
@@ -2,6 +2,8 @@
 
 - **IDP Schema**: [instances/schema/current/idp-v1.0-schema.json](../instances/schema/current/idp-v1.0-schema.json)
 - **CPAS Specification**: [docs/specs/current/CPAS-Core-v1.1.md](specs/current/CPAS-Core-v1.1.md)
+- **CPAS Metadata Schema**: [../../schema/cpas_metadata.schema.json](../../schema/cpas_metadata.schema.json)
+- **T-BEEP Message Schema**: [../../schema/tbeep_message.schema.json](../../schema/tbeep_message.schema.json)
 - **T-BEEP Specification**: [protocols/T-BEEP/](../protocols/T-BEEP/)
 - **Agent Regeneration Guide**: [agents/README.md](../agents/README.md)
 - **Dashboard Usage**: [docs/dashboard_usage.md](dashboard_usage.md)

--- a/schema/cpas_metadata.schema.json
+++ b/schema/cpas_metadata.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CPAS Metadata",
+  "type": "object",
+  "properties": {
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "multipleOf": 0.001
+    },
+    "rifg": {
+      "type": "number",
+      "enum": [0.0, 0.25, 0.5, 0.75, 1.0]
+    },
+    "provenance": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "notes": {"type": "string"}
+  },
+  "required": ["confidence", "rifg", "provenance"],
+  "additionalProperties": false
+}

--- a/schema/tbeep_message.schema.json
+++ b/schema/tbeep_message.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "T-BEEP Message",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "role": {
+      "type": "string",
+      "enum": ["user", "assistant", "agent", "system"]
+    },
+    "sender": {"type": "string"},
+    "recipient": {"type": "string"},
+    "content": {"type": "string"},
+    "metadata": {"$ref": "./cpas_metadata.schema.json"}
+  },
+  "required": ["id", "timestamp", "role", "sender", "recipient", "content", "metadata"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- define JSON schema for CPAS metadata
- define JSON schema for T-BEEP messages
- reference new schemas in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_68583eaa65ac832d9d68c5a89625c33b