### PR TITLE
Add JSON schema validation utilities

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/validation.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/validation.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from jsonschema import RefResolver, validate, validators
+
+# Directory containing schema files at repository root
+_SCHEMAS_DIR = Path(__file__).resolve().parents[5] / "schema"
+
+
+def load_schema(name: str | Path) -> dict:
+    """Load a JSON schema by name or path."""
+    path = Path(name)
+    if not path.is_absolute():
+        path = _SCHEMAS_DIR / path
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_instance(instance: Mapping[str, Any], schema: str | Mapping[str, Any]) -> None:
+    """Validate ``instance`` against ``schema``.
+
+    ``schema`` may be a mapping or the file name of a schema located in
+    the repository ``schema`` directory.
+    """
+    if isinstance(schema, (str, Path)):
+        schema_path = Path(schema)
+        if not schema_path.is_absolute():
+            schema_path = _SCHEMAS_DIR / schema_path
+        schema = load_schema(schema_path)
+        base_uri = f"file://{schema_path.parent.as_posix()}/"
+        validator_cls = validators.validator_for(schema)
+        validator = validator_cls(schema, resolver=RefResolver(base_uri, schema))
+        validator.validate(instance)
+    else:
+        validate(instance=instance, schema=schema)
+
+
+def validate_tbeep_message(message: Any) -> None:
+    """Validate a T-BEEP message or dictionary representation."""
+    if hasattr(message, "model_dump"):
+        instance = message.model_dump(mode="json", exclude_none=True)
+    elif hasattr(message, "to_dict"):
+        instance = message.to_dict()
+    else:
+        instance = dict(message)
+    validate_instance(instance, "tbeep_message.schema.json")

--- a/python/packages/autogen-cpas/tests/test_tbeep_schema.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_schema.py
@@ -1,0 +1,80 @@
+import importlib.util
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT / "python" / "packages" / "autogen-cpas" / "src"))
+autogen_stub = types.ModuleType("autogen")
+autogen_stub.ConversableAgent = object
+autogen_stub.config_list_from_models = lambda models: []
+sys.modules.setdefault("autogen", autogen_stub)
+
+def _load_modules():
+    src_dir = ROOT / "python" / "packages" / "autogen-cpas" / "src"
+    spec_protocol = importlib.util.spec_from_file_location(
+        "autogen_cpas.protocol", src_dir / "autogen_cpas" / "protocol.py"
+    )
+    protocol = importlib.util.module_from_spec(spec_protocol)
+    sys.modules["autogen_cpas.protocol"] = protocol
+    spec_protocol.loader.exec_module(protocol)
+
+    spec_models = importlib.util.spec_from_file_location(
+        "autogen_cpas.models", src_dir / "autogen_cpas" / "models.py"
+    )
+    models = importlib.util.module_from_spec(spec_models)
+    sys.modules["autogen_cpas.models"] = models
+    spec_models.loader.exec_module(models)
+
+    spec_validation = importlib.util.spec_from_file_location(
+        "autogen_cpas.validation", src_dir / "autogen_cpas" / "validation.py"
+    )
+    validation = importlib.util.module_from_spec(spec_validation)
+    sys.modules["autogen_cpas.validation"] = validation
+    spec_validation.loader.exec_module(validation)
+
+    return models, protocol, validation
+
+
+models, protocol, validation = _load_modules()
+CPASMetadata = models.CPASMetadata
+TBeepMessage = models.TBeepMessage
+RIFG = protocol.RIFG
+Role = protocol.Role
+validate_tbeep_message = validation.validate_tbeep_message
+
+
+def _sample_message() -> TBeepMessage:
+    meta = CPASMetadata(confidence=0.5, rifg=RIFG.MEDIUM, provenance=["unit"])
+    return TBeepMessage(
+        id="1",
+        timestamp=datetime(2025, 1, 1, 0, 0, 0),
+        role=Role.USER,
+        sender="alice",
+        recipient="bob",
+        content="hello",
+        metadata=meta,
+    )
+
+
+def test_message_conforms_to_schema() -> None:
+    msg = _sample_message()
+    validate_tbeep_message(msg)
+
+
+def test_invalid_message_raises() -> None:
+    invalid = {
+        "id": "1",
+        "timestamp": "bad",
+        "role": "user",
+        "sender": "alice",
+        "recipient": "bob",
+        "content": "hi",
+        "metadata": {"confidence": 1.2, "rifg": 0.5, "provenance": []},
+    }
+    with pytest.raises(ValidationError):
+        validate_tbeep_message(invalid)


### PR DESCRIPTION
## Summary
- add validation helpers for T-BEEP message schemas
- ensure optional fields are skipped and references resolve
- test schema conformance of sample messages

## Testing
- `ruff check src/autogen_cpas/validation.py tests/test_tbeep_schema.py`
- `pytest tests/test_tbeep_schema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858454bd124832d96dd6f6b3aa48a45