### PR TITLE
Add validation tests for T-BEEP schema and IDP

### DIFF
--- a/python/packages/autogen-cpas/tests/test_tbeep_schema.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_schema.py
@@ -78,3 +78,36 @@ def test_invalid_message_raises() -> None:
     }
     with pytest.raises(ValidationError):
         validate_tbeep_message(invalid)
+
+
+def test_unexpected_message_field() -> None:
+    msg = _sample_message().to_dict()
+    msg["extra"] = "oops"
+    with pytest.raises(ValidationError):
+        validate_tbeep_message(msg)
+
+
+def test_unexpected_metadata_field() -> None:
+    msg = _sample_message().to_dict()
+    msg["metadata"]["extra"] = "nope"
+    with pytest.raises(ValidationError):
+        validate_tbeep_message(msg)
+
+
+def test_missing_message_field() -> None:
+    msg = _sample_message().to_dict()
+    msg.pop("sender")
+    with pytest.raises(ValidationError):
+        validate_tbeep_message(msg)
+
+
+def test_missing_metadata_field() -> None:
+    msg = _sample_message().to_dict()
+    msg["metadata"].pop("provenance")
+    with pytest.raises(ValidationError):
+        validate_tbeep_message(msg)
+
+
+def test_protocol_decode_type_error() -> None:
+    with pytest.raises(TypeError):
+        protocol.decode("not a dict")

--- a/python/packages/autogen-cpas/tests/test_validate_idp.py
+++ b/python/packages/autogen-cpas/tests/test_validate_idp.py
@@ -1,15 +1,41 @@
+import json
+import logging
+import runpy
 import pytest
 
 pytest.importorskip("jsonschema")
-import runpy
 
 validate_module = runpy.run_path("python/packages/autogen-cpas/tests/validate_idp.py")
 validate_instance = validate_module["validate_instance"]
 
 
-def test_validate_instance_pass(capsys):
+def test_validate_instance_pass(caplog):
     instance = "agents/json/openai/Clarence-9.json"
     schema = "agents/idp-v1.0-schema.json"
-    validate_instance(instance, schema)
-    captured = capsys.readouterr().out
-    assert "Validation passed" in captured
+    with caplog.at_level(logging.INFO):
+        validate_instance(instance, schema)
+    assert "Validation passed" in caplog.text
+
+
+def test_validate_instance_missing_field(tmp_path, caplog):
+    schema = "agents/idp-v1.0-schema.json"
+    data = json.load(open("agents/json/openai/Clarence-9.json"))
+    data.pop("instance_name", None)
+    instance_file = tmp_path / "invalid.json"
+    with instance_file.open("w") as f:
+        json.dump(data, f)
+    with caplog.at_level(logging.ERROR):
+        validate_instance(str(instance_file), schema)
+    assert "Validation failed" in caplog.text
+
+
+def test_validate_instance_invalid_enum(tmp_path, caplog):
+    schema = "agents/idp-v1.0-schema.json"
+    data = json.load(open("agents/json/openai/Clarence-9.json"))
+    data["reasoning_transparency_level"] = "extreme"
+    instance_file = tmp_path / "invalid_enum.json"
+    with instance_file.open("w") as f:
+        json.dump(data, f)
+    with caplog.at_level(logging.ERROR):
+        validate_instance(str(instance_file), schema)
+    assert "Validation failed" in caplog.text


### PR DESCRIPTION
## Summary
- extend T-BEEP schema tests for unexpected and missing fields
- check `protocol.decode` type validation
- expand IDP validation tests for error scenarios and capture logging correctly

## Testing
- `pytest python/packages/autogen-cpas/tests/test_tbeep_schema.py python/packages/autogen-cpas/tests/test_validate_idp.py`

------
https://chatgpt.com/codex/tasks/task_e_68584dab22cc832db0df61b9d5022baa