### PR TITLE
Add CPAS agent tests for error handling

### DIFF
--- a/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
+++ b/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
@@ -1,5 +1,12 @@
+import sys
+import types
 import pytest
 from autogen_core import AgentId, SingleThreadedAgentRuntime
+
+autogen_stub = types.ModuleType("autogen")
+autogen_stub.ConversableAgent = object
+autogen_stub.config_list_from_models = lambda models: []
+sys.modules.setdefault("autogen", autogen_stub)
 
 from autogen_cpas.agent import EchoAgent
 from autogen_cpas.models import ChatMessage
@@ -18,3 +25,16 @@ async def test_agent_roundtrip() -> None:
     assert isinstance(response, ChatMessage)
     assert response.role is Role.ASSISTANT
     assert response.content == "ping"
+
+
+@pytest.mark.asyncio
+async def test_send_to_unknown_agent_raises() -> None:
+    runtime = SingleThreadedAgentRuntime()
+    await EchoAgent.register(runtime, "echo", EchoAgent)
+    runtime.start()
+    with pytest.raises(Exception, match="Recipient not found"):
+        await runtime.send_message(
+            ChatMessage(role=Role.USER, content="ping"),
+            recipient=AgentId("missing", "default"),
+        )
+    await runtime.stop()

--- a/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
+++ b/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
@@ -10,6 +10,7 @@ from autogen_core import AgentId, SingleThreadedAgentRuntime
 from autogen_cpas.agent import CpasEnabledAgent
 from autogen_cpas.models import CPASMetadata, TBeepMessage
 from autogen_cpas.protocol import RIFG, Role, decode, encode
+from pydantic import ValidationError
 
 
 @pytest.mark.asyncio
@@ -51,3 +52,57 @@ async def test_cpas_enabled_agents() -> None:
     assert decoded.content == "hello"
     assert decoded.metadata.confidence == pytest.approx(0.6)
     assert decoded.metadata.provenance == ["unit", "receiver"]
+
+
+def test_receive_malformed_message_raises() -> None:
+    agent = CpasEnabledAgent(name="a")
+    with pytest.raises(ValidationError):
+        agent.receive({"bad": "data"})
+
+
+@pytest.mark.asyncio
+async def test_provenance_accumulates() -> None:
+    runtime = SingleThreadedAgentRuntime()
+
+    sender = CpasEnabledAgent(name="sender")
+    receiver = CpasEnabledAgent(name="receiver")
+
+    await sender.register_instance(runtime, AgentId("sender", "default"))
+    await receiver.register_instance(runtime, AgentId("receiver", "default"))
+
+    runtime.start()
+
+    meta = CPASMetadata(confidence=0.5, rifg=RIFG.LOW, provenance=["unit"])
+    msg = TBeepMessage(
+        id="1",
+        timestamp=datetime.utcnow(),
+        role=Role.USER,
+        sender="sender",
+        recipient="receiver",
+        content="hi",
+        metadata=meta,
+    )
+    encoded = encode(msg)
+
+    r1 = await runtime.send_message(
+        encoded,
+        recipient=AgentId("receiver", "default"),
+        sender=AgentId("sender", "default"),
+    )
+
+    r2 = await runtime.send_message(
+        r1,
+        recipient=AgentId("sender", "default"),
+        sender=AgentId("receiver", "default"),
+    )
+
+    r3 = await runtime.send_message(
+        r2,
+        recipient=AgentId("receiver", "default"),
+        sender=AgentId("sender", "default"),
+    )
+
+    await runtime.stop()
+
+    decoded = decode(r3)
+    assert decoded.metadata.provenance == ["unit", "receiver", "sender", "receiver"]


### PR DESCRIPTION
## Summary
- extend agent roundtrip tests to check unknown recipient handling
- verify `CpasEnabledAgent` propagates decode errors
- ensure metadata provenance accumulates across multiple exchanges

## Testing
- `pytest python/packages/autogen-cpas/tests/test_agent_roundtrip.py python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68585012cf00832d8020f152bd79f575