### PR TITLE
Add utility tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_utilities.py
+++ b/python/packages/autogen-cpas/tests/test_utilities.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import datetime
+import json
+
+import pytest
+from cpas_autogen import (
+    continuity_check,
+    should_realign,
+    latest_metrics,
+    metrics_monitor,
+    wrap_with_seed_token,
+    generate_fingerprint,
+)
+
+
+def test_continuity_check_success():
+    seed = {"alignment_profile": "CPAS-Core v1.1"}
+    assert continuity_check(seed, "#COMM_PROTO_X")
+
+
+def test_continuity_check_failure(caplog):
+    seed = {"alignment_profile": "wrong"}
+    with caplog.at_level(logging.WARNING):
+        assert not continuity_check(seed, "BAD")
+        assert any("Seed token alignment" in r.getMessage() for r in caplog.records)
+
+
+def test_should_realign_false():
+    m = {"symbolic_density": 1.0, "interpretive_bandwidth": 1.0, "divergence_score": 1.0}
+    assert not should_realign(m)
+
+
+def test_should_realign_true():
+    m = {"symbolic_density": 0.1, "interpretive_bandwidth": 1.0, "divergence_score": 1.0}
+    assert should_realign(m)
+
+
+def test_latest_metrics_missing(monkeypatch, tmp_path):
+    f = tmp_path / "missing.json"
+    monkeypatch.setattr("cpas_autogen.drift_monitor.DRIFT_LOG", f)
+    assert latest_metrics() == {}
+
+
+def test_latest_metrics_malformed(monkeypatch, tmp_path):
+    f = tmp_path / "bad.json"
+    f.write_text("oops")
+    monkeypatch.setattr("cpas_autogen.drift_monitor.DRIFT_LOG", f)
+    assert latest_metrics() == {}
+
+
+def test_latest_metrics_valid(monkeypatch, tmp_path):
+    data = [{"avg_7_day": {"interpretive_bandwidth": 0.9, "symbolic_density": 0.8, "divergence_space": 0.7}}]
+    f = tmp_path / "log.json"
+    f.write_text(json.dumps(data))
+    monkeypatch.setattr("cpas_autogen.drift_monitor.DRIFT_LOG", f)
+    assert latest_metrics()["divergence_score"] == 0.7
+
+
+class DummyAgent:
+    def __init__(self):
+        self.idp_metadata = {"instance_name": "a"}
+
+
+def test_periodic_metrics_check(monkeypatch):
+    calls = []
+    def fake_diff(current):
+        calls.append(current)
+        return {}
+    monkeypatch.setattr(metrics_monitor, "diff_report", fake_diff)
+    times = [datetime(2024,1,1,0,0,0), datetime(2024,1,1,0,1,0), datetime(2024,1,1,0,31,0)]
+    class FakeDT:
+        @classmethod
+        def utcnow(cls):
+            return times.pop(0)
+    monkeypatch.setattr(metrics_monitor, "datetime", FakeDT)
+    agent = DummyAgent()
+    metrics_monitor.periodic_metrics_check(agent, {"x":1})
+    metrics_monitor.periodic_metrics_check(agent, {"x":2})
+    metrics_monitor.periodic_metrics_check(agent, {"x":3})
+    assert len(calls) == 2
+
+
+def test_wrap_and_fingerprint():
+    seed = {"model": "m", "alignment_profile": "a"}
+    wrapped = wrap_with_seed_token("hello", seed)
+    assert wrapped.startswith("### Seed Instance")
+    fp = generate_fingerprint("hello", seed)
+    assert set(["fingerprint", "timestamp", "prompt", "model", "alignment_profile"]) <= fp.keys()
+    assert len(fp["fingerprint"]) == 64
+


### PR DESCRIPTION
## Summary
- add test coverage for utility functions

## Testing
- `pytest -q tests/test_metrics_monitor.py tests/test_seed_token.py tests/test_utilities.py`

------
https://chatgpt.com/codex/tasks/task_e_6858520f85dc832dbc81dfb56f48db97