### PR TITLE
Add API edge case tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_tbeep_api.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_api.py
@@ -31,3 +31,38 @@ def test_missing_thread_token():
     MESSAGE_STORE.clear()
     res = client.post("/api/v1/messages", json={"content": "x"})
     assert res.status_code == 400
+
+
+def test_invalid_json():
+    client = app.test_client()
+    MESSAGE_STORE.clear()
+    # send malformed JSON payload
+    res = client.post(
+        "/api/v1/messages",
+        data="{bad json",
+        content_type="application/json",
+    )
+    assert res.status_code == 400
+
+
+def test_get_missing_thread_returns_empty():
+    client = app.test_client()
+    MESSAGE_STORE.clear()
+    res = client.get("/api/v1/messages", query_string={"thread_id": "missing"})
+    assert res.status_code == 200
+    assert res.get_json() == []
+
+
+def test_post_multiple_messages():
+    client = app.test_client()
+    MESSAGE_STORE.clear()
+    thread_id = "#TEST_MULTI"
+    msg1 = {"threadToken": thread_id, "content": "one"}
+    msg2 = {"threadToken": thread_id, "content": "two"}
+    res = client.post("/api/v1/messages", json=msg1)
+    assert res.status_code == 201
+    res = client.post("/api/v1/messages", json=msg2)
+    assert res.status_code == 201
+    res = client.get("/api/v1/messages", query_string={"thread_id": thread_id})
+    assert res.status_code == 200
+    assert res.get_json() == [msg1, msg2]


### PR DESCRIPTION
## Summary
- test posting invalid JSON rejects with 400
- verify retrieval on missing thread returns empty
- ensure posting multiple messages retains order

## Testing
- `pytest -q python/packages/autogen-cpas/tests/test_tbeep_api.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_685866fcad24832db2b028c7b3a3a318