### PR TITLE
Add SeedToken validate-failure unit test

### DIFF
--- a/python/packages/autogen-cpas/tests/test_seed_token.py
+++ b/python/packages/autogen-cpas/tests/test_seed_token.py
@@ -13,3 +13,23 @@ def test_generate_and_validate():
     other = SeedToken.generate(data)
     assert token.validate(other)
     assert token.to_dict()["id"] == "1"
+
+
+def test_validate_fails_on_different_tokens():
+    data1 = {
+        "id": "1",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "CPAS",
+        "hash": "abc",
+    }
+    data2 = {
+        "id": "2",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "CPAS",
+        "hash": "abc",
+    }
+    token1 = SeedToken.generate(data1)
+    token2 = SeedToken.generate(data2)
+    assert not token1.validate(token2)


### PR DESCRIPTION
## Summary
- add unit test to ensure validation fails for different SeedTokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685870813214832dbac859b4b04ba8d9