### PR TITLE
Add baseline monitor edge case tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_metrics_monitor.py
+++ b/python/packages/autogen-cpas/tests/test_metrics_monitor.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 from cpas_autogen import metrics_monitor
@@ -11,6 +10,23 @@ def test_load_baseline(tmp_path, monkeypatch):
     f.write_text(json.dumps(data))
     monkeypatch.setattr(metrics_monitor, "BASELINE_FILE", f)
     assert metrics_monitor.load_baseline() == {"x": 1.0}
+
+
+def test_load_baseline_missing(tmp_path, monkeypatch):
+    """load_baseline should return an empty dict when the file is absent."""
+    f = tmp_path / "does_not_exist.json"
+    monkeypatch.setattr(metrics_monitor, "BASELINE_FILE", f)
+    assert metrics_monitor.load_baseline() == {}
+    assert metrics_monitor.diff_report({"a": 1.0}) == {"similarity": 0.0}
+
+
+def test_load_baseline_invalid_json(tmp_path, monkeypatch):
+    """load_baseline should handle invalid JSON gracefully."""
+    f = tmp_path / "bad.json"
+    f.write_text("{invalid json}")
+    monkeypatch.setattr(metrics_monitor, "BASELINE_FILE", f)
+    assert metrics_monitor.load_baseline() == {}
+    assert metrics_monitor.diff_report({"a": 1.0}) == {"similarity": 0.0}
 
 
 def test_diff_report(monkeypatch):


### PR DESCRIPTION
## Summary
- test missing/invalid baseline metrics

## Testing
- `pytest python/packages/autogen-cpas/tests/test_metrics_monitor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68588a2282fc832db4ad859097ce21cf