### PR TITLE
Add malformed message test for generate_reply

### DIFF
--- a/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
+++ b/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
@@ -60,6 +60,12 @@ def test_receive_malformed_message_raises() -> None:
         agent.receive({"bad": "data"})
 
 
+def test_generate_reply_malformed_message_raises() -> None:
+    agent = CpasEnabledAgent(name="a")
+    with pytest.raises(ValidationError):
+        agent.generate_reply([{"bad": "data"}])
+
+
 @pytest.mark.asyncio
 async def test_provenance_accumulates() -> None:
     runtime = SingleThreadedAgentRuntime()


### PR DESCRIPTION
## Summary
- test that `CpasEnabledAgent.generate_reply` raises a `ValidationError` with bad input

## Testing
- `pytest -q tests/test_cpas_enabled_agents.py -vv` *(fails: collected 0 items because autogen missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858910cf9c0832d80e80e72ca52626d