### PR TITLE
Add similarity tests for non-overlapping tokens

### DIFF
--- a/python/packages/autogen-cpas/tests/test_utilities.py
+++ b/python/packages/autogen-cpas/tests/test_utilities.py
@@ -120,3 +120,11 @@ def test_compare_seed_tokens_partial_match():
     assert not report["model"]["match"]
     assert not report["hash"]["match"]
     assert report["similarity"] == pytest.approx(1 / 3)
+
+
+def test_seed_token_no_shared_keys() -> None:
+    token1 = {"foo": 1}
+    token2 = {"bar": 2}
+    assert similarity_score(token1, token2) == 0.0
+    report = compare_seed_tokens(token1, token2)
+    assert report["similarity"] == 0.0


### PR DESCRIPTION
## Summary
- cover zero-overlap case in instance diff utilities

## Testing
- `PYTHONPATH=python/packages/autogen-cpas/src pytest python/packages/autogen-cpas/tests/test_utilities.py::test_seed_token_no_shared_keys -q`


------
https://chatgpt.com/codex/tasks/task_e_685897d56ae4832da2eef1d940664165