### PR TITLE
Add fingerprint inequality test

### DIFF
--- a/python/packages/autogen-cpas/tests/test_utilities.py
+++ b/python/packages/autogen-cpas/tests/test_utilities.py
@@ -128,3 +128,11 @@ def test_seed_token_no_shared_keys() -> None:
     assert similarity_score(token1, token2) == 0.0
     report = compare_seed_tokens(token1, token2)
     assert report["similarity"] == 0.0
+
+
+def test_generate_fingerprint_not_equal() -> None:
+    """Fingerprints should differ for different prompts."""
+    seed = {"model": "m", "alignment_profile": "a"}
+    fp1 = generate_fingerprint("hello", seed)
+    fp2 = generate_fingerprint("bye", seed)
+    assert fp1["fingerprint"] != fp2["fingerprint"]


### PR DESCRIPTION
## Summary
- ensure fingerprints differ when prompts change in utilities tests

## Testing
- `PYTHONPATH=python/packages/autogen-cpas/src pytest python/packages/autogen-cpas/tests/test_utilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858bd20bd34832da8ffd49a9ad8efe6