### PR TITLE
Add SeedToken mismatch tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_seed_token.py
+++ b/python/packages/autogen-cpas/tests/test_seed_token.py
@@ -33,3 +33,43 @@ def test_validate_fails_on_different_tokens():
     token1 = SeedToken.generate(data1)
     token2 = SeedToken.generate(data2)
     assert not token1.validate(token2)
+
+
+def test_validate_fails_on_alignment_profile_mismatch():
+    data1 = {
+        "id": "1",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "CPAS",
+        "hash": "abc",
+    }
+    data2 = {
+        "id": "1",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "OTHER",
+        "hash": "abc",
+    }
+    token1 = SeedToken.generate(data1)
+    token2 = SeedToken.generate(data2)
+    assert not token1.validate(token2)
+
+
+def test_validate_fails_on_hash_mismatch():
+    data1 = {
+        "id": "1",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "CPAS",
+        "hash": "abc",
+    }
+    data2 = {
+        "id": "1",
+        "model": "GPT",
+        "timestamp": "2025",
+        "alignment_profile": "CPAS",
+        "hash": "xyz",
+    }
+    token1 = SeedToken.generate(data1)
+    token2 = SeedToken.generate(data2)
+    assert not token1.validate(token2)


### PR DESCRIPTION
## Summary
- cover mismatched alignment profile and hash in SeedToken validation

## Testing
- `pytest tests/test_seed_token.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c9463b28832d8957ac6a372771a6