### PR TITLE
Add failing validation test for extra IDP property

### DIFF
--- a/python/packages/autogen-cpas/tests/test_validate_idp.py
+++ b/python/packages/autogen-cpas/tests/test_validate_idp.py
@@ -39,3 +39,16 @@ def test_validate_instance_invalid_enum(tmp_path, caplog):
     with caplog.at_level(logging.ERROR):
         validate_instance(str(instance_file), schema)
     assert "Validation failed" in caplog.text
+
+
+def test_validate_instance_additional_property(tmp_path, caplog):
+    """Validation fails when instance has an unexpected property."""
+    schema = "agents/idp-v1.0-schema.json"
+    data = json.load(open("agents/json/openai/Clarence-9.json"))
+    data["bogus_key"] = "bogus"
+    instance_file = tmp_path / "extra_prop.json"
+    with instance_file.open("w") as f:
+        json.dump(data, f)
+    with caplog.at_level(logging.ERROR):
+        validate_instance(str(instance_file), schema)
+    assert "Validation failed" in caplog.text


### PR DESCRIPTION
## Summary
- test_validate_idp: add test for failing when extra property exists

## Testing
- `pytest python/packages/autogen-cpas/tests/test_validate_idp.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859440c6f38832d9a747d3bb546c039