### PR TITLE
Add fingerprint variation test

### DIFF
--- a/python/packages/autogen-cpas/tests/test_utilities.py
+++ b/python/packages/autogen-cpas/tests/test_utilities.py
@@ -151,3 +151,16 @@ def test_fingerprint_differs_for_seed_token() -> None:
     fp1 = generate_fingerprint("hello", seed1)
     fp2 = generate_fingerprint("hello", seed2)
     assert fp1["fingerprint"] != fp2["fingerprint"]
+
+@pytest.mark.parametrize(
+    "prompt1,prompt2,seed1,seed2",
+    [
+        ("alpha", "beta", {"model": "m", "alignment_profile": "a"}, {"model": "m", "alignment_profile": "a"}),
+        ("hello", "hello", {"model": "m1", "alignment_profile": "a"}, {"model": "m2", "alignment_profile": "a"}),
+    ],
+)
+def test_generate_fingerprint_variation(prompt1, prompt2, seed1, seed2) -> None:
+    """Fingerprints should differ when prompts or seed tokens differ."""
+    fp1 = generate_fingerprint(prompt1, seed1)
+    fp2 = generate_fingerprint(prompt2, seed2)
+    assert fp1["fingerprint"] != fp2["fingerprint"]


### PR DESCRIPTION
## Summary
- ensure fingerprints differ when prompts or seed tokens vary

## Testing
- `PYTHONPATH=python/packages/autogen-cpas/src pytest python/packages/autogen-cpas/tests/test_utilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68595053bfb8832d9894d4749c29217e