### PR TITLE
Forbid extra fields in CPAS pydantic models

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/models.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 from .protocol import RIFG, Role
 
@@ -22,6 +22,8 @@ class CPASMetadata(BaseModel):
     rifg: RIFG
     provenance: List[str]
     notes: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("confidence")
     @classmethod
@@ -43,6 +45,8 @@ class TBeepMessage(BaseModel):
     recipient: str
     content: str
     metadata: CPASMetadata
+
+    model_config = ConfigDict(extra="forbid")
 
     def to_dict(self) -> dict:
         """Return the serializable representation."""


### PR DESCRIPTION
## Summary
- update `CPASMetadata` and `TBeepMessage` models to use `ConfigDict(extra="forbid")`
- add `ConfigDict` import

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_685963001aec832dbe711ce6703c8952