### PR TITLE
Fix encode/decode for TBeepMessage

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/protocol.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import json
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Mapping
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .models import TBeepMessage
@@ -26,17 +27,31 @@ class RIFG(float, Enum):
     VERY_HIGH = 1.0
 
 
-def encode(message: "TBeepMessage") -> dict:
-    """Return a dictionary representation of ``message``."""
-    return message.to_dict()
+def encode(message: "TBeepMessage") -> Mapping[str, Any]:
+    """Return a JSON-compatible mapping representation of ``message``.
+
+    Datetime values are converted to ISO 8601 strings and fields with ``None``
+    values are omitted to comply with the JSON schema.
+    """
+
+    return message.model_dump(mode="json", exclude_none=True)
 
 
-def decode(data: dict) -> "TBeepMessage":
-    """Validate ``data`` and return a :class:`TBeepMessage`."""
-    if not isinstance(data, dict):
-        raise TypeError("message must be a dictionary")
+def decode(data: Mapping[str, Any] | str) -> "TBeepMessage":
+    """Validate ``data`` and return a :class:`TBeepMessage`.
+
+    ``data`` may be a mapping or a JSON string produced by :func:`encode`.
+    """
+
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError("message must be valid JSON") from exc
+    if not isinstance(data, Mapping):
+        raise TypeError("message must be a mapping or JSON string")
     from .models import TBeepMessage
-    return TBeepMessage.from_dict(data)
+    return TBeepMessage.from_dict(dict(data))
 
 
 __all__ = ["Role", "RIFG", "encode", "decode"]


### PR DESCRIPTION
## Summary
- update encode/decode in `protocol.py`

## Testing
- `poetry run ruff check src/autogen_cpas/protocol.py`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_68596439ffc0832da7e2d4dbd394ae20