### PR TITLE
Fix provenance propagation

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -45,7 +45,7 @@ class CpasEnabledAgent(ConversableAgent):
         new_meta = CPASMetadata(
             confidence=new_confidence,
             rifg=meta.rifg,
-            provenance=[*meta.provenance, self.name],
+            provenance=[*meta.provenance, incoming.id],
             notes=meta.notes,
         )
         reply = TBeepMessage(

--- a/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
+++ b/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
@@ -51,7 +51,7 @@ async def test_cpas_enabled_agents() -> None:
 
     assert decoded.content == "hello"
     assert decoded.metadata.confidence == pytest.approx(0.6)
-    assert decoded.metadata.provenance == ["unit", "receiver"]
+    assert decoded.metadata.provenance == ["unit", "1"]
 
 
 def test_receive_malformed_message_raises() -> None:
@@ -110,5 +110,7 @@ async def test_provenance_accumulates() -> None:
 
     await runtime.stop()
 
-    decoded = decode(r3)
-    assert decoded.metadata.provenance == ["unit", "receiver", "sender", "receiver"]
+    r1_decoded = decode(r1)
+    r2_decoded = decode(r2)
+    r3_decoded = decode(r3)
+    assert r3_decoded.metadata.provenance == ["unit", "1", r1_decoded.id, r2_decoded.id]


### PR DESCRIPTION
## Summary
- update provenance in `CpasEnabledAgent.generate_reply`
- adjust CPAS enabled agent tests to check provenance IDs

## Testing
- `pytest python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py -q` *(fails: AttributeError: 'CpasEnabledAgent' object has no attribute 'register_instance')*
- `pytest python/packages/autogen-cpas -q` *(fails: ModuleNotFoundError: autogen.core)*

------
https://chatgpt.com/codex/tasks/task_e_68596e1d6df4832db7c0542052c0d842