### PR TITLE
Add async wrapper for CPAS agent

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,4 +1,4 @@
-from .agent import CpasEnabledAgent, EchoAgent
+from .agent import AsyncCpasAgent, CpasEnabledAgent, EchoAgent
 from .models import ChatMessage, CPASMetadata, TBeepMessage
 from .protocol import RIFG, Role, decode, encode
 
@@ -10,6 +10,7 @@ __all__ = [
     "RIFG",
     "EchoAgent",
     "CpasEnabledAgent",
+    "AsyncCpasAgent",
     "encode",
     "decode",
 ]

--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
+import asyncio
+import logging
+from typing import Any, Mapping, Sequence
+
 from autogen import ConversableAgent
-from autogen_core import MessageContext, RoutedAgent, message_handler
+from autogen_agentchat.agents import BaseChatAgent
+from autogen_agentchat.base import Response
+from autogen_agentchat.messages import StructuredMessage
+from autogen_core import CancellationToken, MessageContext, RoutedAgent, message_handler
 
 from .models import ChatMessage, CPASMetadata, TBeepMessage
 from .protocol import Role, decode, encode
@@ -58,3 +65,44 @@ class CpasEnabledAgent(ConversableAgent):
             metadata=new_meta,
         )
         return encode(reply)
+
+
+TBeepChatMessage = StructuredMessage[TBeepMessage]
+
+
+class AsyncCpasAgent(BaseChatAgent):
+    """Asynchronous wrapper around :class:`CpasEnabledAgent`."""
+
+    def __init__(self, inner: CpasEnabledAgent) -> None:
+        super().__init__(inner.name, description=f"{inner.name} async wrapper")
+        self._inner = inner
+        logging.info("Wrapping %s with AsyncCpasAgent", inner.name)
+
+    @property
+    def produced_message_types(self) -> Sequence[type[TBeepChatMessage]]:
+        return (TBeepChatMessage,)
+
+    async def a_receive(self, message: Mapping[str, Any], sender: str | None = None) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._inner.receive, message, sender)
+
+    async def a_generate_reply(
+        self, messages: Sequence[Mapping[str, Any]], sender: str | None = None
+    ) -> Mapping[str, Any]:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._inner.generate_reply, list(messages), sender)
+
+    async def on_messages(
+        self, messages: Sequence[TBeepChatMessage], cancellation_token: CancellationToken
+    ) -> Response:
+        encoded_messages = []
+        for msg in messages:
+            encoded = encode(msg.content)
+            await self.a_receive(encoded, sender=msg.source)
+            encoded_messages.append(encoded)
+        reply = await self.a_generate_reply(encoded_messages, sender=messages[-1].source)
+        decoded = decode(reply)
+        return Response(chat_message=TBeepChatMessage(content=decoded, source=self.name))
+
+    async def on_reset(self, cancellation_token: CancellationToken) -> None:
+        pass

--- a/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
+++ b/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
@@ -1,0 +1,54 @@
+import sys
+import types
+from datetime import datetime
+
+import pytest
+
+autogen_stub = types.ModuleType("autogen")
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def receive(self, *args, **kwargs):
+        pass
+
+    def generate_reply(self, *args, **kwargs):
+        return {}
+
+autogen_stub.ConversableAgent = _DummyCA
+autogen_stub.config_list_from_models = lambda models: []
+sys.modules.setdefault("autogen", autogen_stub)
+
+from autogen_core import CancellationToken
+from autogen_agentchat.messages import StructuredMessage
+
+from autogen_cpas.agent import CpasEnabledAgent, AsyncCpasAgent
+from autogen_cpas.models import CPASMetadata, TBeepMessage
+from autogen_cpas.protocol import RIFG, Role
+
+
+@pytest.mark.asyncio
+async def test_async_cpas_agent_roundtrip() -> None:
+    sync_agent = CpasEnabledAgent()
+    sync_agent.name = "sync"
+    async_agent = AsyncCpasAgent(sync_agent)
+
+    msg = TBeepMessage(
+        id="1",
+        timestamp=datetime.utcnow(),
+        role=Role.USER,
+        sender="user",
+        recipient="sync",
+        content="hello",
+        metadata=CPASMetadata(confidence=0.5, rifg=RIFG.LOW, provenance=["unit"]),
+    )
+    wrapped = StructuredMessage[TBeepMessage](content=msg, source="user")
+
+    response = await async_agent.on_messages([wrapped], CancellationToken())
+    out = response.chat_message.content
+
+    assert out.content == "hello"
+    assert out.recipient == "user"
+    assert out.metadata.confidence == pytest.approx(0.6)
+    assert out.metadata.provenance == ["unit", "1"]
+


### PR DESCRIPTION
## Summary
- support async usage of CPAS by adding `AsyncCpasAgent`
- export new class from package
- test async wrapper

## Testing
- `pytest python/packages/autogen-cpas/tests/test_async_cpas_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859742892f8832d94eef9f35a6bcc7d