### PR TITLE
Update CPAS deps and add skip fixture

### DIFF
--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -12,6 +12,16 @@ requires-python = ">=3.10"
 dependencies = [
     "autogen-core==0.6.1",
     "pydantic>=2,<3",
+    "jsonschema>=4,<5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio",
+    "ruff",
+    "autogen-core==0.6.1",
+    "jsonschema>=4,<5",
 ]
 
 [project.scripts]

--- a/python/packages/autogen-cpas/tests/conftest.py
+++ b/python/packages/autogen-cpas/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.fixture(autouse=True, scope="session")
+def _ensure_autogen_core() -> None:
+    try:
+        import autogen_core  # noqa: F401
+    except Exception:
+        pytest.skip(
+            "autogen_core unavailable; skipping CPAS tests", allow_module_level=True
+        )
+


### PR DESCRIPTION
## Summary
- include jsonschema and dev extras in `autogen-cpas` package
- add fixture to skip CPAS tests when autogen_core is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_68599753a508832da8d3b914c0547e7a