### PR TITLE
Fix license links in package README

### DIFF
--- a/python/packages/autogen-cpas/README.md
+++ b/python/packages/autogen-cpas/README.md
@@ -124,5 +124,6 @@ Contributions are welcome! Please open issues or pull requests via GitHub.
 > Tagline: **Reflect to Adapt. Standardize to Connect.**
 > Companion: **Coherence through Context. Clarity through Reflection.**
 
-**Repository Maintainer:** [SpartanM34](https://github.com/SpartanM34)  
-**License:** [MIT License](./LICENSE)
+**Repository Maintainer:** [SpartanM34](https://github.com/SpartanM34)
+**Code License:** [MIT License](LICENSE-CODE)
+**Documentation License:** [Creative Commons Attribution 4.0 International](../../../LICENSE)


### PR DESCRIPTION
## Summary
- clarify licensing information in python package README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_68599a16a2c0832d86bffd97d70fe863