### PR TITLE
Unify thread_id parameter in T-BEEP API

### DIFF
--- a/python/packages/autogen-cpas/README.md
+++ b/python/packages/autogen-cpas/README.md
@@ -91,7 +91,7 @@ Messages can then be POSTed to `/api/v1/messages` and fetched by thread ID via `
 
 Example usage:
 ```bash
-curl -X POST -H "Content-Type: application/json" -d {"threadToken": "#T1", "content": "hello"} http://localhost:5000/api/v1/messages
+curl -X POST -H "Content-Type: application/json" -d {"thread_id": "#T1", "content": "hello"} http://localhost:5000/api/v1/messages
 curl "http://localhost:5000/api/v1/messages?thread_id=#T1"
 ```
 ### Legacy Web Testing Interface

--- a/python/packages/autogen-cpas/api/tbeep_api.py
+++ b/python/packages/autogen-cpas/api/tbeep_api.py
@@ -22,9 +22,9 @@ def post_message():
     data = request.get_json(force=True, silent=True)
     if not isinstance(data, dict):
         return jsonify({"error": "Invalid JSON"}), 400
-    thread_id = data.get("threadToken")
+    thread_id = data.get("thread_id")
     if not thread_id:
-        return jsonify({"error": "threadToken missing"}), 400
+        return jsonify({"error": "thread_id missing"}), 400
     MESSAGE_STORE.setdefault(thread_id, []).append(data)
     return jsonify({"status": "stored"}), 201
 

--- a/python/packages/autogen-cpas/tests/test_tbeep_api.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_api.py
@@ -10,7 +10,7 @@ def test_post_and_get_message():
     client = app.test_client()
     MESSAGE_STORE.clear()
     msg = {
-        "threadToken": "#TEST_001.0",
+        "thread_id": "#TEST_001.0",
         "instance": "Unit",
         "reasoningLevel": "Detailed",
         "confidence": "High",
@@ -26,7 +26,7 @@ def test_post_and_get_message():
     assert res.get_json() == [msg]
 
 
-def test_missing_thread_token():
+def test_missing_thread_id():
     client = app.test_client()
     MESSAGE_STORE.clear()
     res = client.post("/api/v1/messages", json={"content": "x"})
@@ -57,8 +57,8 @@ def test_post_multiple_messages():
     client = app.test_client()
     MESSAGE_STORE.clear()
     thread_id = "#TEST_MULTI"
-    msg1 = {"threadToken": thread_id, "content": "one"}
-    msg2 = {"threadToken": thread_id, "content": "two"}
+    msg1 = {"thread_id": thread_id, "content": "one"}
+    msg2 = {"thread_id": thread_id, "content": "two"}
     res = client.post("/api/v1/messages", json=msg1)
     assert res.status_code == 201
     res = client.post("/api/v1/messages", json=msg2)


### PR DESCRIPTION
## Summary
- standardize POST and GET routes to use `thread_id`
- update API tests for new parameter
- revise README example to match

## Testing
- `pytest python/packages/autogen-cpas/tests/test_tbeep_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68599bc00e24832d90ceef238061780d