### PR TITLE
Include T-BEEP package

### DIFF
--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -29,7 +29,10 @@ autogen-cpas-api = "autogen_cpas.api.tbeep_api:main"
 autogen-cpas-gen-agents = "cpas_autogen.generate_agents:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/autogen_cpas"]
+packages = [
+    "src/autogen_cpas",
+    "src/T-BEEP",
+]
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,6 +1,7 @@
 from .agent import AsyncCpasAgent, CpasEnabledAgent, EchoAgent
 from .models import ChatMessage, CPASMetadata, TBeepMessage
 from .protocol import RIFG, Role, decode, encode
+from .tbeep_messenger import TBeepMessenger
 
 __all__ = [
     "ChatMessage",
@@ -13,4 +14,5 @@ __all__ = [
     "AsyncCpasAgent",
     "encode",
     "decode",
+    "TBeepMessenger",
 ]

--- a/python/packages/autogen-cpas/src/autogen_cpas/tbeep_messenger.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/tbeep_messenger.py
@@ -1,0 +1,15 @@
+"""Wrapper for T-Beep messenger utilities."""
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+_pkg_path = Path(__file__).resolve().parent.parent / "T-BEEP" / "tbeep_messenger.py"
+_spec = spec_from_file_location("tbeep_messenger", _pkg_path)
+_module = module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore
+
+TBeepMessenger = _module.TBeepMessenger
+TBeepMessage = _module.TBeepMessage
+
+__all__ = ["TBeepMessenger", "TBeepMessage"]


### PR DESCRIPTION
## Summary
- package `src/T-BEEP` with autogen-cpas
- expose `TBeepMessenger` via a small wrapper module

## Testing
- `pip install -e .` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*
- `pytest -q` *(fails: 8 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68599de23aa4832da901b5768ee4c084