### PR TITLE
Update test path loading

### DIFF
--- a/python/packages/autogen-cpas/tests/test_cpas_metadata_roundtrip.py
+++ b/python/packages/autogen-cpas/tests/test_cpas_metadata_roundtrip.py
@@ -2,6 +2,8 @@ import importlib.util
 import sys
 import types
 from datetime import datetime
+from importlib.resources import files
+
 import pytest
 
 
@@ -12,7 +14,7 @@ def _load_modules():
 
     spec_protocol = importlib.util.spec_from_file_location(
         "autogen_cpas.protocol",
-        "python/packages/autogen-cpas/src/autogen_cpas/protocol.py",
+        str(files("autogen_cpas").joinpath("protocol.py")),
     )
     protocol = importlib.util.module_from_spec(spec_protocol)
     protocol.__package__ = "autogen_cpas"
@@ -21,7 +23,7 @@ def _load_modules():
 
     spec_models = importlib.util.spec_from_file_location(
         "autogen_cpas.models",
-        "python/packages/autogen-cpas/src/autogen_cpas/models.py",
+        str(files("autogen_cpas").joinpath("models.py")),
     )
     models = importlib.util.module_from_spec(spec_models)
     models.__package__ = "autogen_cpas"

--- a/python/packages/autogen-cpas/tests/test_validate_idp.py
+++ b/python/packages/autogen-cpas/tests/test_validate_idp.py
@@ -1,11 +1,14 @@
 import json
 import logging
 import runpy
+from importlib.resources import files
+
 import pytest
 
 pytest.importorskip("jsonschema")
 
-validate_module = runpy.run_path("python/packages/autogen-cpas/tests/validate_idp.py")
+validate_path = files("autogen_cpas.tests").joinpath("validate_idp.py")
+validate_module = runpy.run_path(str(validate_path))
 validate_instance = validate_module["validate_instance"]
 
 


### PR DESCRIPTION
## Summary
- simplify protocol module loading
- reference validate_idp using importlib.resources

## Testing
- `ruff check tests/test_cpas_metadata_roundtrip.py tests/test_validate_idp.py`
- `pytest tests/test_validate_idp.py -k test_validate_instance_pass -vv` *(fails: collected 0 items)*

------
https://chatgpt.com/codex/tasks/task_e_6859b0f0323c832dadc7625b5a649ad6