### PR TITLE
Fix CpasEnabledAgent base method calls

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -58,10 +58,13 @@ class EchoAgent(RoutedAgent):
 class CpasEnabledAgent(ConversableAgent):
     """Conversable agent that echoes messages with updated CPAS metadata."""
 
+    def __init__(self, name: str = "bot", **kwargs) -> None:
+        super().__init__(name=name, **kwargs)
+
     def receive(self, message, sender=None, **kwargs):  # type: ignore[override]
         """Validate ``message`` using :func:`decode` before delegating."""
         decode(message)
-        return super().receive(message, sender=sender, **kwargs)
+        return ConversableAgent.receive(self, message, sender=sender, **kwargs)
 
     def generate_reply(self, messages, sender=None, **kwargs):  # type: ignore[override]
         """Return an echo response with updated confidence and provenance."""


### PR DESCRIPTION
## Summary
- add explicit `__init__` to CpasEnabledAgent
- call `ConversableAgent.receive` directly in `receive`

## Testing
- `pytest tests/test_async_cpas_agent.py -vv` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_6859c2e51c88832da0b22f6b49439bad