### PR TITLE
Fix schema URI handling

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/validation.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/validation.py
@@ -2,19 +2,24 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any, Mapping
 
 from jsonschema import RefResolver, validate, validators
 
-# Directory containing schema files at repository root
-_SCHEMAS_DIR = Path(__file__).resolve().parents[5] / "schema"
+LOCAL_DIR = Path(__file__).parent.parent.parent  # repo root
+SCHEMA_DIR = LOCAL_DIR / "schema"
+
+
+def _schema_uri(name: str) -> str:
+    return (SCHEMA_DIR / name).resolve().as_uri()
 
 
 def load_schema(name: str | Path) -> dict:
     """Load a JSON schema by name or path."""
     path = Path(name)
     if not path.is_absolute():
-        path = _SCHEMAS_DIR / path
+        path = Path(urlparse(_schema_uri(str(name))).path)
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -28,9 +33,9 @@ def validate_instance(instance: Mapping[str, Any], schema: str | Mapping[str, An
     if isinstance(schema, (str, Path)):
         schema_path = Path(schema)
         if not schema_path.is_absolute():
-            schema_path = _SCHEMAS_DIR / schema_path
+            schema_path = SCHEMA_DIR / schema_path
         schema = load_schema(schema_path)
-        base_uri = f"file://{schema_path.parent.as_posix()}/"
+        base_uri = schema_path.parent.resolve().as_uri() + "/"
         validator_cls = validators.validator_for(schema)
         validator = validator_cls(schema, resolver=RefResolver(base_uri, schema))
         validator.validate(instance)


### PR DESCRIPTION
## Summary
- centralize schema directory handling
- generate file URIs with `_schema_uri`
- remove hard-coded `file://` strings in schema validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_6859c39bb158832dbb0ba4162de0f8e3