### PR TITLE
Fix decode schema test

### DIFF
--- a/python/packages/autogen-cpas/tests/test_tbeep_schema.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_schema.py
@@ -108,6 +108,6 @@ def test_missing_metadata_field() -> None:
         validate_tbeep_message(msg)
 
 
-def test_protocol_decode_type_error() -> None:
-    with pytest.raises(TypeError):
+def test_protocol_decode_value_error() -> None:
+    with pytest.raises(ValueError):
         protocol.decode("not a dict")


### PR DESCRIPTION
## Summary
- test protocol.decode error
- expect `ValueError` for invalid JSON
- rename the test to reflect the exception type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_6859c77784a8832db9568a67585b1c31