### PR TITLE
Fix Bayesian confidence update

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -41,7 +41,7 @@ def aggregate_bayesian_confidence(scores: Sequence[float]) -> float:
     posterior = scores[0]
     for score in scores[1:]:
         posterior = _bayesian_confidence(posterior, score)
-    return posterior
+    return _bayesian_confidence(posterior)
 
 
 class EchoAgent(RoutedAgent):


### PR DESCRIPTION
## Summary
- fix `aggregate_bayesian_confidence` so single confidence values update with reliability
- keep async receive using `run_in_executor`

## Testing
- `python -m pytest python/packages/autogen-cpas/tests/test_async_cpas_agent.py::test_async_cpas_agent_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cdb38fb8832daa4f988e320b0544