### PR TITLE
Update autogen import

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -16,6 +16,7 @@ from typing import Any, Iterable, Mapping, Sequence
 #     "content": "hello",
 #     "metadata": {"confidence": 0.6, "rifg": 0.25, "provenance": ["unit"]}
 # }
+# Import ConversableAgent from the updated autogen package
 from autogen import ConversableAgent
 from autogen_agentchat.agents import BaseChatAgent
 from autogen_agentchat.base import Response


### PR DESCRIPTION
## Summary
- adjust comments around ConversableAgent import

## Testing
- `ruff format src/autogen_cpas/agent.py`
- `ruff check src/autogen_cpas/agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_cpas')*
- `mypy --config-file ../../pyproject.toml src/autogen_cpas/agent.py` *(fails: found 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859cf198148832d893463ad0fd1ac43