### PR TITLE
Include ChatMessage import

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -1,5 +1,5 @@
 from .agent import AsyncCpasAgent, CpasEnabledAgent, EchoAgent
-from .models import CPASMetadata, TBeepMessage
+from .models import CPASMetadata, TBeepMessage, ChatMessage
 from .protocol import RIFG, Role, decode, encode
 from .tbeep_messenger import TBeepMessenger
 


### PR DESCRIPTION
## Summary
- include `ChatMessage` in the `autogen_cpas` package import list

## Testing
- `pytest -q python/packages/autogen-cpas/tests/test_models.py::test_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cf226e4c832db333142933dae3b1