### PR TITLE
Fix ConversableAgent stubs and update init

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -59,8 +59,8 @@ class EchoAgent(RoutedAgent):
 class CpasEnabledAgent(ConversableAgent):
     """Conversable agent that echoes messages with updated CPAS metadata."""
 
-    def __init__(self, name: str = "bot", **kwargs) -> None:
-        super().__init__(name=name, **kwargs)
+    def __init__(self, name: str = "bot", *args, **kwargs) -> None:
+        super().__init__(name, *args, **kwargs)
 
     def receive(self, message, sender=None, **kwargs):  # type: ignore[override]
         """Validate ``message`` using :func:`decode` before delegating."""

--- a/python/packages/autogen-cpas/tests/test_generated_agents.py
+++ b/python/packages/autogen-cpas/tests/test_generated_agents.py
@@ -10,7 +10,14 @@ sys.path.insert(0, str(ROOT / "python" / "packages" / "autogen-cpas" / "src"))
 
 # Provide a minimal stub for the optional 'autogen' dependency
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 

--- a/python/packages/autogen-cpas/tests/test_memory_confidence.py
+++ b/python/packages/autogen-cpas/tests/test_memory_confidence.py
@@ -12,7 +12,14 @@ from autogen_cpas.protocol import RIFG, Role, decode, encode
 
 # Stub optional autogen dependency
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 

--- a/python/packages/autogen-cpas/tests/test_models.py
+++ b/python/packages/autogen-cpas/tests/test_models.py
@@ -2,7 +2,14 @@ import sys
 import types
 
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 

--- a/python/packages/autogen-cpas/tests/test_schema_enforcement.py
+++ b/python/packages/autogen-cpas/tests/test_schema_enforcement.py
@@ -11,7 +11,14 @@ sys.path.insert(0, str(ROOT / "python" / "packages" / "autogen-cpas" / "src"))
 
 # Provide a minimal stub for the optional 'autogen' dependency
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 

--- a/python/packages/autogen-cpas/tests/test_tbeep_messenger.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_messenger.py
@@ -8,7 +8,14 @@ sys.path.insert(0, str(ROOT / "python" / "packages" / "autogen-cpas" / "src"))
 
 # stub autogen module to satisfy optional imports
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 

--- a/python/packages/autogen-cpas/tests/test_tbeep_schema.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_schema.py
@@ -10,7 +10,14 @@ from jsonschema import ValidationError
 ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(ROOT / "python" / "packages" / "autogen-cpas" / "src"))
 autogen_stub = types.ModuleType("autogen")
-autogen_stub.ConversableAgent = object
+
+
+class _DummyCA:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+
+autogen_stub.ConversableAgent = _DummyCA
 autogen_stub.config_list_from_models = lambda models: []
 sys.modules.setdefault("autogen", autogen_stub)
 


### PR DESCRIPTION
## Summary
- accept `*args, **kwargs` in `CpasEnabledAgent.__init__`
- update tests to stub `ConversableAgent` with a dummy class implementing `__init__`

## Testing
- `pytest -q` *(fails: pydantic validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859d3314ce0832d9a6db6e1d16b23cb