### PR TITLE
Fix T-BEEP messenger imports

### DIFF
--- a/python/packages/autogen-cpas/src/T-BEEP/tbeep_messenger.py
+++ b/python/packages/autogen-cpas/src/T-BEEP/tbeep_messenger.py
@@ -1,10 +1,10 @@
-from __future__ import annotations
-
 """Utilities for constructing T-BEEP messages."""
 
+from __future__ import annotations
+
+import uuid
 from datetime import datetime
 from typing import Any, Optional
-import uuid
 
 from autogen_cpas.models import CPASMetadata, TBeepMessage
 from autogen_cpas.protocol import RIFG, Role


### PR DESCRIPTION
## Summary
- move imports in `tbeep_messenger.py` below the docstring

## Testing
- `ruff check src/T-BEEP/tbeep_messenger.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_6859d3328d90832d8301c21f0d31c301