### PR TITLE
Fix numpy import in baseline_metrics

### DIFF
--- a/python/packages/autogen-cpas/tools/baseline_metrics.py
+++ b/python/packages/autogen-cpas/tools/baseline_metrics.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import numpy as np
 import spacy
 import torch
 from sentence_transformers import util
@@ -69,5 +70,4 @@ def main():
 
 
 if __name__ == "__main__":
-    import numpy as np
     main()


### PR DESCRIPTION
## Summary
- import numpy at module level in baseline_metrics
- remove duplicate import in `__main__` guard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6859d44172d8832db7de553d3b9d1b23