### PR TITLE
Remove duplicate import in __init__

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/__init__.py
@@ -2,7 +2,6 @@ from .agent import AsyncCpasAgent, CpasEnabledAgent, EchoAgent
 from .models import ChatMessage, CPASMetadata, TBeepMessage
 from .protocol import RIFG, Role, decode, encode
 from .tbeep_messenger import TBeepMessenger
-from .models import ChatMessage
 
 __all__ = [
     "CpasEnabledAgent",


### PR DESCRIPTION
## Summary
- remove extra `ChatMessage` import
- reorder imports using ruff

## Testing
- `ruff check --fix python/packages/autogen-cpas/src/autogen_cpas/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d8bda298832d9b8b0caecdfb952b