### PR TITLE
Fix E402 warnings in tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
+++ b/python/packages/autogen-cpas/tests/test_agent_roundtrip.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 import types
 

--- a/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
+++ b/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 import types
 from datetime import datetime

--- a/python/packages/autogen-cpas/tests/test_epistemic_mixin.py
+++ b/python/packages/autogen-cpas/tests/test_epistemic_mixin.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 from pathlib import Path
 

--- a/python/packages/autogen-cpas/tests/test_models.py
+++ b/python/packages/autogen-cpas/tests/test_models.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 import types
 

--- a/python/packages/autogen-cpas/tests/test_schema_enforcement.py
+++ b/python/packages/autogen-cpas/tests/test_schema_enforcement.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 import types
 from datetime import datetime

--- a/python/packages/autogen-cpas/tests/test_utilities.py
+++ b/python/packages/autogen-cpas/tests/test_utilities.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import json
 import logging
 from datetime import datetime


### PR DESCRIPTION
## Summary
- silence Ruff E402 warnings in the test suite

## Testing
- `ruff check python/packages/autogen-cpas/tests`

------
https://chatgpt.com/codex/tasks/task_e_6859d8be9e9c832dafe63664359c9cbd