### PR TITLE
Fix schema directory for validation

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/schema/cpas_metadata.schema.json
+++ b/python/packages/autogen-cpas/src/autogen_cpas/schema/cpas_metadata.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CPAS Metadata",
+  "type": "object",
+  "properties": {
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "multipleOf": 0.001
+    },
+    "rifg": {
+      "type": "number",
+      "enum": [0.0, 0.25, 0.5, 0.75, 1.0]
+    },
+    "provenance": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "notes": {"type": "string"}
+  },
+  "required": ["confidence", "rifg", "provenance"],
+  "additionalProperties": false
+}

--- a/python/packages/autogen-cpas/src/autogen_cpas/schema/tbeep_message.schema.json
+++ b/python/packages/autogen-cpas/src/autogen_cpas/schema/tbeep_message.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "T-BEEP Message",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "role": {
+      "type": "string",
+      "enum": ["user", "assistant", "agent", "system"]
+    },
+    "sender": {"type": "string"},
+    "recipient": {"type": "string"},
+    "content": {"type": "string"},
+    "metadata": {"$ref": "./cpas_metadata.schema.json"}
+  },
+  "required": ["id", "timestamp", "role", "sender", "recipient", "content", "metadata"],
+  "additionalProperties": false
+}

--- a/python/packages/autogen-cpas/src/autogen_cpas/validation.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/validation.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 from jsonschema import RefResolver, validate, validators
 
-PACKAGE_SCHEMAS = Path(__file__).with_suffix("").parent.parent / "schema"
+PACKAGE_SCHEMAS = Path(__file__).parent / "schema"
 
 
 def load_schema(name: str | Path) -> dict:


### PR DESCRIPTION
## Summary
- update `PACKAGE_SCHEMAS` to point at sibling *schema* directory
- include schema JSON files inside `autogen_cpas/schema`

## Testing
- `pip install -e python/packages/autogen-cpas[dev]`
- `pip install -e ../../../python/packages/autogen-agentchat`
- `pytest -q` *(fails: ModuleNotFoundError: cannot import name 'CPASMetadata' from 'autogen_cpas.models')*

------
https://chatgpt.com/codex/tasks/task_e_6859e0eb250c832d84b2d12386b5da50