### PR TITLE
Update ChatMessage.simple metadata handling

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/models.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/models.py
@@ -65,5 +65,7 @@ class ChatMessage(TBeepMessage):
             sender="tester",
             recipient="echo",
             content=content,
-            metadata=CPASMetadata(confidence=0.5, rifg=RIFG.MEDIUM, provenance=[]),
+            metadata=CPASMetadata(
+                confidence=0.5, rifg=RIFG.MEDIUM, provenance=[]
+            ).model_dump(mode="python"),
         )


### PR DESCRIPTION
## Summary
- return model-dumped metadata when creating simple `ChatMessage`

## Testing
- `pytest python/packages/autogen-cpas/tests/test_models.py::test_roundtrip -q` *(fails: ModuleNotFoundError: cannot import name 'trace_create_agent_span' from 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_6859e3624ba4832d844867626bde907a