### PR TITLE
Return dict from async agent

### DIFF
--- a/python/packages/autogen-cpas/src/autogen_cpas/agent.py
+++ b/python/packages/autogen-cpas/src/autogen_cpas/agent.py
@@ -157,7 +157,12 @@ class AsyncCpasAgent(BaseChatAgent):
             encoded_messages.append(encoded)
         reply = await self.a_generate_reply(encoded_messages, sender=messages[-1].source)
         decoded = decode(reply)
-        return Response(chat_message=TBeepChatMessage(content=decoded, source=self.name))
+        return Response(
+            chat_message=TBeepChatMessage(
+                content=decoded.model_dump(mode="python"),
+                source=self.name,
+            )
+        )
 
     async def on_reset(self, cancellation_token: CancellationToken) -> None:
         pass

--- a/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
+++ b/python/packages/autogen-cpas/tests/test_async_cpas_agent.py
@@ -55,8 +55,8 @@ async def test_async_cpas_agent_roundtrip() -> None:
     response = await async_agent.on_messages([wrapped], CancellationToken())
     out = response.chat_message.content
 
-    assert out.content == "hello"
-    assert out.recipient == "user"
-    assert out.metadata.confidence == pytest.approx(0.6)
-    assert out.metadata.provenance == ["unit", "1"]
+    assert out["content"] == "hello"
+    assert out["recipient"] == "user"
+    assert out["metadata"]["confidence"] == pytest.approx(0.6)
+    assert out["metadata"]["provenance"] == ["unit", "1"]
 


### PR DESCRIPTION
## Summary
- return the pydantic dump from `AsyncCpasAgent.on_messages`
- update async agent test for dict content

## Testing
- `pytest python/packages/autogen-cpas/tests/test_async_cpas_agent.py::test_async_cpas_agent_roundtrip -q` *(fails: ModuleNotFoundError: No module named 'autogen_agentchat')*

------
https://chatgpt.com/codex/tasks/task_e_6859e4127acc832db97a996cba6e8bdf