### PR TITLE
Fix ruff include patterns

### DIFF
--- a/python/packages/agbench/pyproject.toml
+++ b/python/packages/agbench/pyproject.toml
@@ -44,7 +44,7 @@ agbench = "agbench.cli:main"
 extend = "../../pyproject.toml"
 exclude = ["build", "dist", "page_script.js", "src/agbench/res/Dockerfile", "src/agbench/template/global_init.sh"]
 include = [
-    "src/**"
+    "src/**/*.py"
 ]
 
 [tool.ruff.lint]

--- a/python/packages/autogen-agentchat/pyproject.toml
+++ b/python/packages/autogen-agentchat/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [tool.ruff]
 extend = "../../pyproject.toml"
-include = ["src/**", "tests/*.py"]
+include = ["src/**/*.py", "tests/**/*.py"]
 
 [tool.pyright]
 extends = "../../pyproject.toml"

--- a/python/packages/autogen-core/pyproject.toml
+++ b/python/packages/autogen-core/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
 [tool.ruff]
 extend = "../../pyproject.toml"
 exclude = ["build", "dist", "src/autogen_core/application/protos", "tests/protos"]
-include = ["src/**", "docs/**/*.ipynb", "tests/**"]
+include = ["src/**/*.py", "docs/**/*.ipynb", "tests/**/*.py"]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/**.ipynb" = ["T20"]

--- a/python/packages/autogen-cpas/pyproject.toml
+++ b/python/packages/autogen-cpas/pyproject.toml
@@ -36,7 +36,7 @@ packages = [
 
 [tool.ruff]
 extend = "../../pyproject.toml"
-include = ["src/**", "tests/*.py"]
+include = ["src/**/*.py", "tests/**/*.py"]
 
 [tool.pyright]
 extends = "../../pyproject.toml"

--- a/python/packages/autogen-ext/pyproject.toml
+++ b/python/packages/autogen-ext/pyproject.toml
@@ -169,7 +169,7 @@ dev = [
 
 [tool.ruff]
 extend = "../../pyproject.toml"
-include = ["src/**", "tests/*.py"]
+include = ["src/**/*.py", "tests/**/*.py"]
 exclude = ["src/autogen_ext/agents/web_surfer/*.js", "src/autogen_ext/runtimes/grpc/protos", "tests/protos", "README.md"]
 
 [tool.pyright]

--- a/python/packages/autogen-test-utils/pyproject.toml
+++ b/python/packages/autogen-test-utils/pyproject.toml
@@ -11,7 +11,7 @@ version        ="0.0.0"
 
 [tool.ruff]
 extend ="../../pyproject.toml"
-include=[ "src/**" ]
+include=[ "src/**/*.py" ]
 
 [tool.pyright]
 extends="../../pyproject.toml"

--- a/python/packages/component-schema-gen/pyproject.toml
+++ b/python/packages/component-schema-gen/pyproject.toml
@@ -21,7 +21,7 @@ gen-component-schema="component_schema_gen.__main__:main"
 
 [tool.ruff]
 extend ="../../pyproject.toml"
-include=[ "src/**" ]
+include=[ "src/**/*.py" ]
 
 [tool.ruff.lint]
 ignore=[ "T201" ]

--- a/python/packages/magentic-one-cli/pyproject.toml
+++ b/python/packages/magentic-one-cli/pyproject.toml
@@ -28,7 +28,7 @@ dev=[ "types-PyYAML" ]
 
 [tool.ruff]
 extend ="../../pyproject.toml"
-include=[ "src/**", "tests/*.py" ]
+include=[ "src/**/*.py", "tests/**/*.py" ]
 
 [tool.pyright]
 extends="../../pyproject.toml"


### PR DESCRIPTION
## Summary
- restrict `tool.ruff` include globs to only search for Python files
- match test files with `tests/**/*.py`

## Testing
- `ruff check --no-fix python/packages/agbench -q`
- `for pkg in python/packages/*; do if [ -f "$pkg/pyproject.toml" ]; then ruff check --no-fix $pkg; fi; done`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb54e64832dafd1f608e360714b