### PR TITLE
Ensure imports precede runtime code in tests

### DIFF
--- a/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
+++ b/python/packages/autogen-cpas/tests/test_cpas_enabled_agents.py
@@ -1,16 +1,15 @@
-import pytest
-
-pytest.importorskip("autogen")
-pytest.importorskip("autogen.core")
-
 from datetime import datetime
 
+import pytest
 from autogen_core import AgentId, SingleThreadedAgentRuntime
 from pydantic import ValidationError
 
 from autogen_cpas.agent import CpasEnabledAgent
 from autogen_cpas.models import CPASMetadata, TBeepMessage
 from autogen_cpas.protocol import RIFG, Role, decode, encode
+
+pytest.importorskip("autogen")
+pytest.importorskip("autogen.core")
 
 
 @pytest.mark.asyncio

--- a/python/packages/autogen-cpas/tests/test_seed_token_agent.py
+++ b/python/packages/autogen-cpas/tests/test_seed_token_agent.py
@@ -1,10 +1,10 @@
-import pytest
-
-pytest.importorskip("autogen")
 import logging
 import types
 
+import pytest
 from agents.python import Lumin
+
+pytest.importorskip("autogen")
 
 
 class DummyAgent:

--- a/python/packages/autogen-cpas/tests/test_tbeep_api.py
+++ b/python/packages/autogen-cpas/tests/test_tbeep_api.py
@@ -1,9 +1,10 @@
-import pytest
-
-pytest.importorskip("flask")
 import json
 
+import pytest
+
 from api.tbeep_api import MESSAGE_STORE, app
+
+pytest.importorskip("flask")
 
 
 def test_post_and_get_message():


### PR DESCRIPTION
## Summary
- move `pytest.importorskip` calls below imports in several test modules
- confirm `ruff` no longer reports `E402` in `autogen-cpas`

## Testing
- `ruff check tests/test_cpas_enabled_agents.py tests/test_seed_token_agent.py tests/test_tbeep_api.py`
- `ruff check . | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb6ca44832d8f0fb423fd866707