### PR TITLE
Use asyncio.Event for cancellation logic

### DIFF
--- a/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
+++ b/python/packages/autogen-core/src/autogen_core/_single_threaded_agent_runtime.py
@@ -120,10 +120,11 @@ class RunContext:
         self._runtime._message_queue.shutdown(immediate=True)  # type: ignore
         await self._run_task
 
-    async def stop_when(self, condition: Callable[[], bool], check_period: float = 1.0) -> None:
+    async def stop_when(self, condition: Callable[[], bool], *, condition_event: asyncio.Event) -> None:
         async def check_condition() -> None:
             while not condition():
-                await asyncio.sleep(check_period)
+                await condition_event.wait()
+                condition_event.clear()
             await self.stop()
 
         await asyncio.create_task(check_condition())
@@ -852,23 +853,20 @@ class SingleThreadedAgentRuntime(AgentRuntime):
             self._run_context = None
             self._message_queue = Queue()
 
-    async def stop_when(self, condition: Callable[[], bool]) -> None:
+    async def stop_when(self, condition: Callable[[], bool], *, condition_event: asyncio.Event) -> None:
         """Stop the runtime message processing loop when the condition is met.
 
         .. caution::
 
-            This method is not recommended to be used, and is here for legacy
-            reasons. It will spawn a busy loop to continually check the
-            condition. It is much more efficient to call `stop_when_idle` or
-            `stop` instead. If you need to stop the runtime based on a
-            condition, consider using a background task and asyncio.Event to
-            signal when the condition is met and the background task should call
-            stop.
+            This method is not recommended to be used. It expects an
+            ``asyncio.Event`` that will be set whenever the condition may have
+            changed. Use :py:meth:`stop_when_idle` or :py:meth:`stop` when
+            possible.
 
         """
         if self._run_context is None:
             raise RuntimeError("Runtime is not started")
-        await self._run_context.stop_when(condition)
+        await self._run_context.stop_when(condition, condition_event=condition_event)
 
         self._run_context = None
         self._message_queue = Queue()

--- a/python/packages/autogen-core/tests/test_cancellation.py
+++ b/python/packages/autogen-core/tests/test_cancellation.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass
+from typing import Any
 
 import pytest
 from autogen_core import (
@@ -68,11 +69,21 @@ async def test_cancellation_with_token() -> None:
     await LongRunningAgent.register(runtime, "long_running", LongRunningAgent)
     agent_id = AgentId("long_running", key="default")
     token = CancellationToken()
-    response = asyncio.create_task(runtime.send_message(MessageType(), recipient=agent_id, cancellation_token=token))
+    message_enqueued = asyncio.Event()
+    orig_put = runtime._message_queue.put  # type: ignore[attr-defined]
+
+    async def put_with_event(item: Any) -> None:
+        await orig_put(item)
+        message_enqueued.set()
+
+    runtime._message_queue.put = put_with_event  # type: ignore[attr-defined]
+
+    response = asyncio.create_task(
+        runtime.send_message(MessageType(), recipient=agent_id, cancellation_token=token)
+    )
     assert not response.done()
 
-    while runtime.unprocessed_messages_count == 0:
-        await asyncio.sleep(0.01)
+    await message_enqueued.wait()
 
     await runtime._process_next()  # type: ignore
 
@@ -101,11 +112,19 @@ async def test_nested_cancellation_only_outer_called() -> None:
     long_running_id = AgentId("long_running", key="default")
     nested_id = AgentId("nested", key="default")
     token = CancellationToken()
+    message_enqueued = asyncio.Event()
+    orig_put = runtime._message_queue.put  # type: ignore[attr-defined]
+
+    async def put_with_event(item: Any) -> None:
+        await orig_put(item)
+        message_enqueued.set()
+
+    runtime._message_queue.put = put_with_event  # type: ignore[attr-defined]
+
     response = asyncio.create_task(runtime.send_message(MessageType(), nested_id, cancellation_token=token))
     assert not response.done()
 
-    while runtime.unprocessed_messages_count == 0:
-        await asyncio.sleep(0.01)
+    await message_enqueued.wait()
 
     await runtime._process_next()  # type: ignore
     token.cancel()
@@ -137,11 +156,19 @@ async def test_nested_cancellation_inner_called() -> None:
     nested_id = AgentId("nested", key="default")
 
     token = CancellationToken()
+    message_enqueued = asyncio.Event()
+    orig_put = runtime._message_queue.put  # type: ignore[attr-defined]
+
+    async def put_with_event(item: Any) -> None:
+        await orig_put(item)
+        message_enqueued.set()
+
+    runtime._message_queue.put = put_with_event  # type: ignore[attr-defined]
+
     response = asyncio.create_task(runtime.send_message(MessageType(), nested_id, cancellation_token=token))
     assert not response.done()
 
-    while runtime.unprocessed_messages_count == 0:
-        await asyncio.sleep(0.01)
+    await message_enqueued.wait()
 
     await runtime._process_next()  # type: ignore
     # allow the inner agent to process


### PR DESCRIPTION
## Summary
- avoid polling with `sleep` in `_single_threaded_agent_runtime.stop_when`
- signal message arrival with `Event` in cancellation tests

## Testing
- `ruff check | grep ASYNC110`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb7ecf8832d8f66190b6d301675