### PR TITLE
Fix E721 in model context tests

### DIFF
--- a/python/packages/autogen-core/tests/test_model_context.py
+++ b/python/packages/autogen-core/tests/test_model_context.py
@@ -202,6 +202,6 @@ async def test_token_limited_model_context_openai_with_function_result(
 
     retrieved = await model_context.get_messages()
     assert len(retrieved) == 3  # Token limit set very low, will remove 1 of the messages
-    assert type(retrieved[0]) == UserMessage  # Function result should be removed
-    assert type(retrieved[1]) == AssistantMessage
-    assert type(retrieved[2]) == UserMessage
+    assert isinstance(retrieved[0], UserMessage)  # Function result should be removed
+    assert isinstance(retrieved[1], AssistantMessage)
+    assert isinstance(retrieved[2], UserMessage)


### PR DESCRIPTION
## Summary
- update type equality checks to use `isinstance`
- verify E721 is resolved with `ruff`

## Testing
- `ruff check --select E721`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb926a4832da3151528f8c81e4c