### PR TITLE
Add DKA persistence helpers

### DIFF
--- a/agents/python/Clarence_9.py
+++ b/agents/python/Clarence_9.py
@@ -6,6 +6,13 @@ from cpas_autogen.continuity_check import continuity_check
 from cpas_autogen.drift_monitor import latest_metrics
 from cpas_autogen.realignment_trigger import should_realign
 from cpas_autogen.metrics_monitor import periodic_metrics_check
+from cpas_autogen.dka_persistence import (
+    generate_digest,
+    store_digest,
+    retrieve_digests,
+    rehydrate_context,
+)
+import atexit
 import logging
 
 IDP_METADATA = {
@@ -108,6 +115,8 @@ Ethical Framework: Value-sensitive design with emphasis on user autonomy and co-
     agent.idp_metadata = IDP_METADATA
     seed_token = SeedToken.generate(IDP_METADATA)
     agent.seed_token = seed_token
+    rehydrate_context(agent, retrieve_digests(IDP_METADATA["instance_name"]))
+    atexit.register(lambda: store_digest(generate_digest(agent)))
     return agent
 
 
@@ -125,6 +134,8 @@ def send_message(agent, prompt: str, thread_token: str, **kwargs):
                 "Auto realignment triggered for %s", agent.idp_metadata["instance_name"]
             )
             agent.seed_token = SeedToken.generate(agent.idp_metadata)
-    return agent.generate_reply(
+    response = agent.generate_reply(
         [{"role": "user", "content": wrapped}], sender=agent, **kwargs
     )
+    agent.last_digest = generate_digest(agent)
+    return response

--- a/agents/python/Lumin.py
+++ b/agents/python/Lumin.py
@@ -6,6 +6,13 @@ from cpas_autogen.continuity_check import continuity_check
 from cpas_autogen.drift_monitor import latest_metrics
 from cpas_autogen.realignment_trigger import should_realign
 from cpas_autogen.metrics_monitor import periodic_metrics_check
+from cpas_autogen.dka_persistence import (
+    generate_digest,
+    store_digest,
+    retrieve_digests,
+    rehydrate_context,
+)
+import atexit
 import logging
 
 IDP_METADATA = {
@@ -103,6 +110,8 @@ Ethical Framework: Designed to promote respectful and safe interactions"""
     agent.idp_metadata = IDP_METADATA
     seed_token = SeedToken.generate(IDP_METADATA)
     agent.seed_token = seed_token
+    rehydrate_context(agent, retrieve_digests(IDP_METADATA["instance_name"]))
+    atexit.register(lambda: store_digest(generate_digest(agent)))
     return agent
 
 
@@ -120,6 +129,8 @@ def send_message(agent, prompt: str, thread_token: str, **kwargs):
                 "Auto realignment triggered for %s", agent.idp_metadata["instance_name"]
             )
             agent.seed_token = SeedToken.generate(agent.idp_metadata)
-    return agent.generate_reply(
+    response = agent.generate_reply(
         [{"role": "user", "content": wrapped}], sender=agent, **kwargs
     )
+    agent.last_digest = generate_digest(agent)
+    return response

--- a/agents/python/Meridian.py
+++ b/agents/python/Meridian.py
@@ -6,6 +6,13 @@ from cpas_autogen.continuity_check import continuity_check
 from cpas_autogen.drift_monitor import latest_metrics
 from cpas_autogen.realignment_trigger import should_realign
 from cpas_autogen.metrics_monitor import periodic_metrics_check
+from cpas_autogen.dka_persistence import (
+    generate_digest,
+    store_digest,
+    retrieve_digests,
+    rehydrate_context,
+)
+import atexit
 import logging
 
 IDP_METADATA = {
@@ -108,6 +115,8 @@ Ethical Framework: Multi-layered: Constitutional, Consequentialist, and Virtue E
     agent.idp_metadata = IDP_METADATA
     seed_token = SeedToken.generate(IDP_METADATA)
     agent.seed_token = seed_token
+    rehydrate_context(agent, retrieve_digests(IDP_METADATA["instance_name"]))
+    atexit.register(lambda: store_digest(generate_digest(agent)))
     return agent
 
 
@@ -125,6 +134,8 @@ def send_message(agent, prompt: str, thread_token: str, **kwargs):
                 "Auto realignment triggered for %s", agent.idp_metadata["instance_name"]
             )
             agent.seed_token = SeedToken.generate(agent.idp_metadata)
-    return agent.generate_reply(
+    response = agent.generate_reply(
         [{"role": "user", "content": wrapped}], sender=agent, **kwargs
     )
+    agent.last_digest = generate_digest(agent)
+    return response

--- a/agents/python/Telos.py
+++ b/agents/python/Telos.py
@@ -6,6 +6,13 @@ from cpas_autogen.continuity_check import continuity_check
 from cpas_autogen.drift_monitor import latest_metrics
 from cpas_autogen.realignment_trigger import should_realign
 from cpas_autogen.metrics_monitor import periodic_metrics_check
+from cpas_autogen.dka_persistence import (
+    generate_digest,
+    store_digest,
+    retrieve_digests,
+    rehydrate_context,
+)
+import atexit
 import logging
 
 IDP_METADATA = {
@@ -118,6 +125,8 @@ Ethical Framework: Governed by Google's AI Principles, prioritizing safety, fair
     agent.idp_metadata = IDP_METADATA
     seed_token = SeedToken.generate(IDP_METADATA)
     agent.seed_token = seed_token
+    rehydrate_context(agent, retrieve_digests(IDP_METADATA["instance_name"]))
+    atexit.register(lambda: store_digest(generate_digest(agent)))
     return agent
 
 
@@ -135,6 +144,8 @@ def send_message(agent, prompt: str, thread_token: str, **kwargs):
                 "Auto realignment triggered for %s", agent.idp_metadata["instance_name"]
             )
             agent.seed_token = SeedToken.generate(agent.idp_metadata)
-    return agent.generate_reply(
+    response = agent.generate_reply(
         [{"role": "user", "content": wrapped}], sender=agent, **kwargs
     )
+    agent.last_digest = generate_digest(agent)
+    return response

--- a/python/packages/autogen-cpas/src/cpas_autogen/dka_persistence.py
+++ b/python/packages/autogen-cpas/src/cpas_autogen/dka_persistence.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+# Repository root -> docs/examples/dka_digests
+ROOT = Path(__file__).resolve().parents[5]
+DEFAULT_DIGEST_DIR = ROOT / "docs" / "examples" / "dka_digests"
+
+
+def generate_digest(agent: Any) -> Dict[str, Any]:
+    """Return a simplified DKA digest derived from ``agent`` state."""
+    now = datetime.utcnow().isoformat()
+    digest = {
+        "digest_version": "1.0",
+        "digest_id": f"DKA_{uuid.uuid4()}",
+        "creation_timestamp": now,
+        "last_modified": now,
+        "participating_instances": [
+            getattr(agent, "idp_metadata", {}).get("instance_name", "unknown")
+        ],
+        "core_metaphor": {"primary": "", "stability": "stable", "evolution_triggers": []},
+        "confidence_gradient": {"overall": 1.0, "components": {}},
+        "assumption_tree": {"root_assumption": "", "dependencies": []},
+        "evolution_history": [],
+        "contested_zones": [],
+        "temporal_metadata": {
+            "validity_horizon": {},
+            "epistemic_half_life": {},
+            "invalidation_triggers": [],
+        },
+        "inter_dka_linkages": [],
+        "rehydration_instructions": {
+            "priority_concepts": [],
+            "required_context": "",
+            "initialization_prompts": [],
+        },
+        "seed_fingerprint": getattr(agent, "last_fingerprint", None),
+    }
+    return digest
+
+
+def store_digest(digest: Dict[str, Any], directory: Path = DEFAULT_DIGEST_DIR) -> Path:
+    """Persist ``digest`` as a JSON file in ``directory``."""
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{digest['digest_id']}.json"
+    path.write_text(json.dumps(digest, indent=2))
+    return path
+
+
+def retrieve_digests(
+    instance_name: str | None = None, directory: Path = DEFAULT_DIGEST_DIR
+) -> List[Dict[str, Any]]:
+    """Return digests stored in ``directory`` optionally filtered by instance."""
+    if not directory.exists():
+        return []
+    digests = []
+    for file in directory.glob("*.json"):
+        try:
+            data = json.loads(file.read_text())
+        except Exception:
+            continue
+        if instance_name and instance_name not in data.get("participating_instances", []):
+            continue
+        digests.append(data)
+    return digests
+
+
+def rehydrate_context(agent: Any, digests: Iterable[Dict[str, Any]]) -> None:
+    """Attach ``digests`` to ``agent`` for later use."""
+    digests = list(digests)
+    if digests:
+        agent.rehydrated_digests = digests
+
+
+__all__ = [
+    "generate_digest",
+    "store_digest",
+    "retrieve_digests",
+    "rehydrate_context",
+    "DEFAULT_DIGEST_DIR",
+]

--- a/python/packages/autogen-cpas/tests/test_generated_agents.py
+++ b/python/packages/autogen-cpas/tests/test_generated_agents.py
@@ -43,6 +43,11 @@ def test_create_agent(monkeypatch):
     monkeypatch.setattr(Telos, "ConversableAgent", StubAgent)
     monkeypatch.setattr(Telos, "config_list_from_models", lambda models: ["cfg"])
     monkeypatch.setattr(Telos, "config_list", ["cfg"])
+    monkeypatch.setattr(Telos, "retrieve_digests", lambda *a, **k: [])
+    monkeypatch.setattr(Telos, "rehydrate_context", lambda *a, **k: None)
+    monkeypatch.setattr(Telos.atexit, "register", lambda f: None)
+    monkeypatch.setattr(Telos, "store_digest", lambda *a, **k: None)
+    monkeypatch.setattr(Telos, "generate_digest", lambda *a, **k: {})
     agent = Telos.create_agent()
     assert isinstance(agent, StubAgent)
     assert agent.idp_metadata["instance_name"] == "Telos"
@@ -57,6 +62,7 @@ def test_send_message(monkeypatch):
     monkeypatch.setattr(Telos, "latest_metrics", lambda: {})
     monkeypatch.setattr(Telos, "periodic_metrics_check", lambda a, m: None)
     monkeypatch.setattr(Telos, "should_realign", lambda m: False)
+    monkeypatch.setattr(Telos, "generate_digest", lambda *a, **k: {})
     result = Telos.send_message(agent, "hi", "#COMM_PROTO_X")
     assert result["role"] == "assistant"
     assert agent.last_fingerprint is not None

--- a/python/packages/autogen-cpas/tests/test_seed_token_agent.py
+++ b/python/packages/autogen-cpas/tests/test_seed_token_agent.py
@@ -20,6 +20,11 @@ class DummyAgent:
 def test_create_agent_has_seed_token(monkeypatch):
     monkeypatch.setattr(Lumin, "ConversableAgent", DummyAgent)
     Lumin.config_list = [{}]
+    monkeypatch.setattr(Lumin, "retrieve_digests", lambda *a, **k: [])
+    monkeypatch.setattr(Lumin, "rehydrate_context", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin.atexit, "register", lambda f: None)
+    monkeypatch.setattr(Lumin, "store_digest", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin, "generate_digest", lambda *a, **k: {})
     agent = Lumin.create_agent()
     assert hasattr(agent, "seed_token")
     assert agent.seed_token is not None
@@ -28,6 +33,11 @@ def test_create_agent_has_seed_token(monkeypatch):
 def test_send_message_warns_on_continuity_failure(monkeypatch, caplog):
     monkeypatch.setattr(Lumin, "ConversableAgent", DummyAgent)
     Lumin.config_list = [{}]
+    monkeypatch.setattr(Lumin, "retrieve_digests", lambda *a, **k: [])
+    monkeypatch.setattr(Lumin, "rehydrate_context", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin.atexit, "register", lambda f: None)
+    monkeypatch.setattr(Lumin, "store_digest", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin, "generate_digest", lambda *a, **k: {})
     agent = Lumin.create_agent()
     caplog.set_level(logging.WARNING)
     Lumin.send_message(agent, "hello", thread_token="INVALID")
@@ -37,6 +47,11 @@ def test_send_message_warns_on_continuity_failure(monkeypatch, caplog):
 def test_send_message_invokes_metric_monitor(monkeypatch):
     monkeypatch.setattr(Lumin, "ConversableAgent", DummyAgent)
     Lumin.config_list = [{}]
+    monkeypatch.setattr(Lumin, "retrieve_digests", lambda *a, **k: [])
+    monkeypatch.setattr(Lumin, "rehydrate_context", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin.atexit, "register", lambda f: None)
+    monkeypatch.setattr(Lumin, "store_digest", lambda *a, **k: None)
+    monkeypatch.setattr(Lumin, "generate_digest", lambda *a, **k: {})
     agent = Lumin.create_agent()
 
     monkeypatch.setattr(Lumin, "latest_metrics", lambda: {"interpretive_bandwidth": 1.0})


### PR DESCRIPTION
## Summary
- implement `dka_persistence` for DKA-E digests
- integrate digest generation/rehydration in generated agents
- keep example digest directory in docs
- update tests for new persistence hooks

## Testing
- `ruff check --fix python/packages/autogen-cpas/src/cpas_autogen/dka_persistence.py`
- `ruff check --fix agents/python/Clarence_9.py agents/python/Lumin.py agents/python/Meridian.py agents/python/Telos.py`
- `ruff check --fix python/packages/autogen-cpas/tests/test_generated_agents.py python/packages/autogen-cpas/tests/test_seed_token_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'autogen_core')*

------
https://chatgpt.com/codex/tasks/task_e_688939a6c6fc832db2626d006a9d568b